### PR TITLE
feat(auth): drop JWT polling, add cold-start loading overlay

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -4,11 +4,13 @@ import { Bar, Pie, Line } from 'react-chartjs-2';
 import { getAllEmployees } from '../services/employeeService';
 import { getAllDepartments } from '../services/departmentService';
 import { Chart, CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend, ArcElement } from 'chart.js';
-import { Card, CardContent, Grid, Typography, Box, CircularProgress, Button, Stack, Chip, Divider } from '@mui/material';
+import { Card, CardContent, Grid, Typography, Box, Button, Stack, Chip, Divider } from '@mui/material';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import LoadingOverlay from './LoadingOverlay';
+import { getUsername } from '../services/authService';
 
 Chart.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend, ArcElement);
 
@@ -111,7 +113,7 @@ const Dashboard = () => {
     'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
   ];
 
-  const username = localStorage.getItem('EMSusername') || 'there';
+  const username = getUsername() || 'there';
   const averageTeamSize = departmentCount ? (employeeCount / departmentCount).toFixed(1) : 0;
   const projectedGrowth = employeeGrowth.length
     ? Math.round(((employeeGrowth[employeeGrowth.length - 1].count - employeeGrowth[0].count) / employeeGrowth[0].count) * 100)
@@ -257,24 +259,7 @@ const Dashboard = () => {
       : null;
 
   if (loading) {
-    return (
-      <Box
-        sx={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          backgroundColor: 'rgba(255, 255, 255, 0.8)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          zIndex: 1000,
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingOverlay message="Crunching the latest org data…" />;
   }
 
   return (

--- a/frontend/src/components/DepartmentList.js
+++ b/frontend/src/components/DepartmentList.js
@@ -29,6 +29,8 @@ import {
   FormControlLabel,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import LoadingOverlay from './LoadingOverlay';
+import useAuth from '../hooks/useAuth';
 
 const DepartmentList = () => {
   const navigate = useNavigate();
@@ -38,20 +40,14 @@ const DepartmentList = () => {
   const [rowsPerPage, setRowsPerPage] = useState(5);
   const [loading, setLoading] = useState(false);
   const [deletingDepartmentId, setDeletingDepartmentId] = useState(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { authenticated: isLoggedIn } = useAuth();
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [sortDirection, setSortDirection] = useState('asc');
   const [denseRows, setDenseRows] = useState(false);
 
-  // Check login status
   useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      setIsLoggedIn(true);
-    } else {
-      setShowSnackbar(true);
-    }
-  }, [navigate]);
+    if (!isLoggedIn) setShowSnackbar(true);
+  }, [isLoggedIn]);
 
   // Fetch departments data if logged in
   useEffect(() => {
@@ -128,24 +124,7 @@ const DepartmentList = () => {
   const visibleDepartments = filteredDepartments.length;
 
   if (loading) {
-    return (
-      <Box
-        sx={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          backgroundColor: 'rgba(255, 255, 255, 0.8)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          zIndex: 1000,
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingOverlay message="Loading departments…" />;
   }
 
   const handleCloseSnackbar = () => {

--- a/frontend/src/components/EmployeeList.js
+++ b/frontend/src/components/EmployeeList.js
@@ -32,6 +32,8 @@ import {
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EmailIcon from '@mui/icons-material/Email';
+import LoadingOverlay from './LoadingOverlay';
+import useAuth from '../hooks/useAuth';
 
 const EmployeeList = () => {
   const navigate = useNavigate();
@@ -41,7 +43,7 @@ const EmployeeList = () => {
   const [rowsPerPage, setRowsPerPage] = useState(5);
   const [loading, setLoading] = useState(false);
   const [deletingEmployeeId, setDeletingEmployeeId] = useState(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { authenticated: isLoggedIn } = useAuth();
   const [showSnackbar, setShowSnackbar] = useState(false);
   const [departments, setDepartments] = useState([]);
   const [departmentFilter, setDepartmentFilter] = useState('all');
@@ -50,13 +52,8 @@ const EmployeeList = () => {
   const [denseRows, setDenseRows] = useState(false);
 
   useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      setIsLoggedIn(true);
-    } else {
-      setShowSnackbar(true);
-    }
-  }, [navigate]);
+    if (!isLoggedIn) setShowSnackbar(true);
+  }, [isLoggedIn]);
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -175,24 +172,7 @@ const EmployeeList = () => {
   };
 
   if (loading) {
-    return (
-      <Box
-        sx={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          backgroundColor: 'rgba(255, 255, 255, 0.8)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          zIndex: 1000,
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingOverlay message="Loading employees…" />;
   }
 
   const handleCloseSnackbar = () => {

--- a/frontend/src/components/LoadingOverlay.js
+++ b/frontend/src/components/LoadingOverlay.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Box, CircularProgress, Typography, Tooltip, IconButton, Fade, Stack } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+const DEFAULT_TIP_DELAY_MS = 4000;
+
+const tooltipContent = (
+  <Box sx={{ p: 0.5, maxWidth: 280 }}>
+    <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
+      Why is this slow?
+    </Typography>
+    <Typography variant="caption" sx={{ display: 'block', lineHeight: 1.55 }}>
+      Our backend runs on Render's free tier (512&nbsp;MB RAM, 0.1 CPU). When it has been idle the instance spins down, and a cold start typically takes 30–60&nbsp;seconds. Once it is warm, requests are much faster.
+    </Typography>
+  </Box>
+);
+
+const LoadingOverlay = ({ message = 'Loading…', tipDelayMs = DEFAULT_TIP_DELAY_MS, fullScreen = true }) => {
+  const [showTip, setShowTip] = useState(false);
+
+  useEffect(() => {
+    if (tipDelayMs <= 0) {
+      setShowTip(true);
+      return undefined;
+    }
+    const timer = setTimeout(() => setShowTip(true), tipDelayMs);
+    return () => clearTimeout(timer);
+  }, [tipDelayMs]);
+
+  const containerSx = fullScreen
+    ? {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 1300,
+      }
+    : {
+        position: 'relative',
+        width: '100%',
+        minHeight: 240,
+      };
+
+  return (
+    <Box
+      role="status"
+      aria-live="polite"
+      sx={{
+        ...containerSx,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(255, 255, 255, 0.88)',
+        backdropFilter: 'blur(3px)',
+        px: 2,
+      }}
+    >
+      <CircularProgress />
+      <Typography sx={{ mt: 2, fontWeight: 500, color: '#1E3C72' }}>{message}</Typography>
+
+      <Fade in={showTip} timeout={500} unmountOnExit>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            mt: 3,
+            px: 2,
+            py: 1.25,
+            maxWidth: 480,
+            backgroundColor: 'rgba(63, 81, 181, 0.08)',
+            border: '1px solid rgba(63, 81, 181, 0.2)',
+            borderRadius: 2,
+            boxShadow: '0 6px 20px rgba(15, 23, 42, 0.08)',
+          }}
+        >
+          <Typography variant="body2" sx={{ color: '#1E3C72', textAlign: 'left' }}>
+            Our server is taking a little longer than usual — thanks for hanging on!
+          </Typography>
+          <Tooltip arrow placement="top" enterTouchDelay={0} leaveTouchDelay={6000} title={tooltipContent}>
+            <IconButton size="small" aria-label="Why is this loading slowly?" sx={{ color: '#1E3C72' }}>
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Fade>
+    </Box>
+  );
+};
+
+export default LoadingOverlay;

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -19,6 +19,8 @@ import {
 } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { setSession } from '../services/authService';
+import LoadingOverlay from './LoadingOverlay';
 
 const Login = () => {
   const [username, setUsername] = useState('');
@@ -48,8 +50,7 @@ const Login = () => {
       setLoading(false);
 
       if (response.ok) {
-        localStorage.setItem('token', data.token);
-        localStorage.setItem('EMSusername', username);
+        setSession(data.token, username);
         setSuccessOpen(true);
       } else {
         setError('Invalid credentials. Please try again.');
@@ -164,15 +165,9 @@ const Login = () => {
                   },
                 }}
               />
-              {loading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                  <CircularProgress />
-                </Box>
-              ) : (
-                <Button fullWidth variant="contained" color="primary" type="submit" sx={{ paddingY: 1.2 }}>
-                  Login
-                </Button>
-              )}
+              <Button fullWidth variant="contained" color="primary" type="submit" disabled={loading} sx={{ paddingY: 1.2 }}>
+                {loading ? <CircularProgress size={24} sx={{ color: 'inherit' }} /> : 'Login'}
+              </Button>
               {error && (
                 <Typography color="error" textAlign="center" sx={{ marginTop: '-0.5rem' }}>
                   {error}
@@ -197,6 +192,8 @@ const Login = () => {
           </form>
         </CardContent>
       </Card>
+
+      {loading && <LoadingOverlay message="Signing you in…" />}
 
       <Dialog open={successOpen} onClose={handleSuccessContinue} aria-labelledby="login-success-title">
         <DialogTitle id="login-success-title">Login successful</DialogTitle>

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -6,7 +6,6 @@ import {
   CardContent,
   Typography,
   Box,
-  CircularProgress,
   IconButton,
   InputAdornment,
   Stack,
@@ -166,7 +165,7 @@ const Login = () => {
                 }}
               />
               <Button fullWidth variant="contained" color="primary" type="submit" disabled={loading} sx={{ paddingY: 1.2 }}>
-                {loading ? <CircularProgress size={24} sx={{ color: 'inherit' }} /> : 'Login'}
+                {loading ? 'Signing in…' : 'Login'}
               </Button>
               {error && (
                 <Typography color="error" textAlign="center" sx={{ marginTop: '-0.5rem' }}>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,15 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { AppBar, Toolbar, Typography, Button, Box, IconButton, Drawer, List, ListItem, ListItemText } from '@mui/material';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import MenuIcon from '@mui/icons-material/Menu';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import useAuth from '../hooks/useAuth';
+import { clearSession } from '../services/authService';
 
 const Navbar = () => {
   const location = useLocation();
   const currentPath = location.pathname;
   const navigate = useNavigate();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { authenticated: isLoggedIn } = useAuth();
 
   // Check if screen width is below 1000px
   const isMobile = useMediaQuery('(max-width:1000px)');
@@ -20,22 +22,8 @@ const Navbar = () => {
     setDrawerOpen(!drawerOpen);
   };
 
-  useEffect(() => {
-    const checkLoginStatus = () => {
-      const token = localStorage.getItem('token');
-      setIsLoggedIn(!!token);
-    };
-
-    checkLoginStatus();
-    const interval = setInterval(checkLoginStatus, 2000);
-
-    return () => clearInterval(interval);
-  }, []);
-
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('EMSusername');
-    setIsLoggedIn(false);
+    clearSession();
     navigate('/login');
   };
 

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -3,7 +3,6 @@ import {
   Box,
   Typography,
   Button,
-  CircularProgress,
   Snackbar,
   Alert,
   Grid,
@@ -19,6 +18,9 @@ import {
 import { useNavigate, Link } from 'react-router-dom';
 import { getAllEmployees } from '../services/employeeService';
 import { getAllDepartments } from '../services/departmentService';
+import LoadingOverlay from './LoadingOverlay';
+import useAuth from '../hooks/useAuth';
+import { clearSession } from '../services/authService';
 import ShieldIcon from '@mui/icons-material/Shield';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import LogoutIcon from '@mui/icons-material/Logout';
@@ -29,7 +31,7 @@ import EmailIcon from '@mui/icons-material/Email';
 
 const Profile = () => {
   const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { authenticated: isLoggedIn, username: authUsername } = useAuth();
   const [employeeCount, setEmployeeCount] = useState(0);
   const [departmentCount, setDepartmentCount] = useState(0);
   const [averageAge, setAverageAge] = useState(0);
@@ -37,17 +39,8 @@ const Profile = () => {
   const [showSnackbar, setShowSnackbar] = useState(false);
 
   useEffect(() => {
-    const checkLoginStatus = () => {
-      const token = localStorage.getItem('token');
-      if (token) {
-        setIsLoggedIn(true);
-      } else {
-        setShowSnackbar(true); // Show the snackbar notification
-      }
-    };
-
-    checkLoginStatus();
-  }, [navigate]);
+    if (!isLoggedIn) setShowSnackbar(true);
+  }, [isLoggedIn]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -106,23 +99,11 @@ const Profile = () => {
   }
 
   if (loading) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          height: '100vh',
-          backgroundColor: 'background.default',
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingOverlay message="Loading your profile…" />;
   }
 
   const profileData = {
-    username: localStorage.getItem('EMSusername') || 'John Doe',
+    username: authUsername || 'John Doe',
     employeeCount,
     departmentCount,
     averageAge,
@@ -135,7 +116,7 @@ const Profile = () => {
   const displayEmail = email.length > 34 ? `${email.slice(0, 32)}…` : email;
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
+    clearSession();
     navigate('/login');
   };
 

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import useAuth from '../hooks/useAuth';
 
 const ProtectedRoute = ({ children }) => {
   const location = useLocation();
-  const token = localStorage.getItem('token');
+  const { authenticated } = useAuth();
 
-  if (!token) {
+  if (!authenticated) {
     return <Navigate to="/login" replace state={{ from: location.pathname }} />;
   }
 

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { isAuthenticated, getUsername, subscribeAuth } from '../services/authService';
+
+const readState = () => ({
+  authenticated: isAuthenticated(),
+  username: getUsername(),
+});
+
+const useAuth = () => {
+  const [state, setState] = useState(readState);
+
+  useEffect(() => {
+    const sync = () => {
+      const next = readState();
+      setState(prev => (prev.authenticated === next.authenticated && prev.username === next.username ? prev : next));
+    };
+    sync();
+    return subscribeAuth(sync);
+  }, []);
+
+  return state;
+};
+
+export default useAuth;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,0 +1,114 @@
+const TOKEN_KEY = 'token';
+const USERNAME_KEY = 'EMSusername';
+const AUTH_EVENT = 'auth-change';
+
+const authEvents = new EventTarget();
+let expiryTimer = null;
+
+const decodeJwt = token => {
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '==='.slice((base64.length + 3) % 4);
+    const json = decodeURIComponent(
+      atob(padded)
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    return JSON.parse(json);
+  } catch (err) {
+    return null;
+  }
+};
+
+const getExpiryMs = token => {
+  const decoded = decodeJwt(token);
+  if (!decoded || typeof decoded.exp !== 'number') return null;
+  return decoded.exp * 1000;
+};
+
+const emitAuthChange = authenticated => {
+  authEvents.dispatchEvent(new CustomEvent(AUTH_EVENT, { detail: { authenticated } }));
+};
+
+const clearExpiryTimer = () => {
+  if (expiryTimer) {
+    clearTimeout(expiryTimer);
+    expiryTimer = null;
+  }
+};
+
+const scheduleExpiry = token => {
+  clearExpiryTimer();
+  if (!token) return;
+  const expiryMs = getExpiryMs(token);
+  if (!expiryMs) return;
+  const delay = expiryMs - Date.now();
+  if (delay <= 0) {
+    clearSession();
+    return;
+  }
+  // setTimeout in browsers caps at ~24.8 days; JWT lifetime here is 7 days, safe.
+  expiryTimer = setTimeout(() => {
+    clearSession();
+  }, delay);
+};
+
+export const getToken = () => localStorage.getItem(TOKEN_KEY);
+
+export const getUsername = () => localStorage.getItem(USERNAME_KEY);
+
+export const isAuthenticated = () => {
+  const token = getToken();
+  if (!token) return false;
+  const expiryMs = getExpiryMs(token);
+  if (expiryMs !== null && expiryMs <= Date.now()) {
+    clearSession();
+    return false;
+  }
+  return true;
+};
+
+export const setSession = (token, username) => {
+  if (!token) return;
+  localStorage.setItem(TOKEN_KEY, token);
+  if (username) localStorage.setItem(USERNAME_KEY, username);
+  scheduleExpiry(token);
+  emitAuthChange(true);
+};
+
+export const clearSession = () => {
+  const hadToken = !!localStorage.getItem(TOKEN_KEY);
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USERNAME_KEY);
+  clearExpiryTimer();
+  if (hadToken) emitAuthChange(false);
+};
+
+export const subscribeAuth = handler => {
+  const onAuth = e => handler(e.detail.authenticated);
+  authEvents.addEventListener(AUTH_EVENT, onAuth);
+  return () => authEvents.removeEventListener(AUTH_EVENT, onAuth);
+};
+
+const handleStorage = e => {
+  if (e.key !== TOKEN_KEY && e.key !== null) return;
+  const token = getToken();
+  scheduleExpiry(token);
+  emitAuthChange(!!token && isAuthenticated());
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', handleStorage);
+  const initialToken = getToken();
+  if (initialToken) {
+    const expiryMs = getExpiryMs(initialToken);
+    if (expiryMs !== null && expiryMs <= Date.now()) {
+      clearSession();
+    } else {
+      scheduleExpiry(initialToken);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **JWT polling → event-driven auth.** Replaced the 2 s `setInterval` token check in `Navbar` with a centralized `authService` that decodes the JWT, schedules a single `setTimeout` for the exact expiry instant, and notifies subscribers via `EventTarget` + `storage` (cross-tab). A new `useAuth()` hook fans this out to `Navbar`, `ProtectedRoute`, `Profile`, `EmployeeList`, `DepartmentList`. `Login` and `Profile` logout now go through `setSession` / `clearSession` so auth state propagates instantly.
- **Long-loading tip overlay.** New shared `LoadingOverlay` component replaces the four duplicated inline `CircularProgress` overlays in `Dashboard`, `EmployeeList`, `DepartmentList`, `Profile`, and is also shown during login. After 4 s a tip fades in ("our server is taking a little longer than usual…") with an info icon whose tooltip explains the Render free-tier specs (512 MB RAM, 0.1 CPU, 30–60 s cold start) — values lifted from the README so users know why the first request is slow.

## Files

- New: `frontend/src/services/authService.js`, `frontend/src/hooks/useAuth.js`, `frontend/src/components/LoadingOverlay.js`
- Updated: `Navbar.js`, `ProtectedRoute.js`, `Login.js`, `Profile.js`, `Dashboard.js`, `EmployeeList.js`, `DepartmentList.js`

## Test plan

- [ ] `npm run build` in `frontend/` (verified locally, compiles cleanly)
- [ ] Log in → confirm overlay shows during the request, and after ~4 s the cold-start tip + tooltip appear
- [ ] Wait for or force-expire the JWT (or manually clear it in DevTools) → confirm Navbar updates to logged-out instantly without the 2 s lag
- [ ] Log out in one tab → confirm a second tab updates to logged-out state via the `storage` event
- [ ] Visit `/dashboard`, `/employees`, `/departments`, `/profile` while not logged in → confirm `ProtectedRoute` redirects to `/login`


---
_Generated by [Claude Code](https://claude.ai/code/session_01S1Mo26BWFQkUKTccsFypgA)_