### PR TITLE
fix(landing): prevent horizontal scroll on mobile

### DIFF
--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -571,7 +571,7 @@ const trustedBy = ['Atlas HR', 'Northwind Ops', 'Acme Labs', 'Cobalt Systems', '
  * ------------------------------------------------------------------ */
 const LandingPage = () => {
   return (
-    <Box sx={{ position: 'relative', width: '100%', color: TEXT, background: PAGE_BG, minHeight: '100vh' }}>
+    <Box sx={{ position: 'relative', width: '100%', maxWidth: '100%', overflowX: 'clip', color: TEXT, background: PAGE_BG, minHeight: '100vh' }}>
       {/* Page-wide procedural 3D — fixed behind every section, including the CTA. */}
       <HeroBackground />
 
@@ -1063,7 +1063,7 @@ const LandingPage = () => {
         </Container>
 
         {/* ===================== FINAL CTA (3D shows through) ===================== */}
-        <Box component="section" sx={{ position: 'relative', py: { xs: 8, md: 12 } }}>
+        <Box component="section" sx={{ position: 'relative', py: { xs: 8, md: 12 }, overflow: 'hidden' }}>
           <Box
             aria-hidden
             sx={{
@@ -1073,7 +1073,7 @@ const LandingPage = () => {
               transform: 'translate(-50%, -50%)',
               width: 760,
               height: 760,
-              maxWidth: '120vw',
+              maxWidth: '100%',
               borderRadius: '50%',
               background: 'radial-gradient(circle, rgba(255,152,0,0.20), transparent 60%)',
               pointerEvents: 'none',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 
+/* Never allow horizontal scroll. `clip` (not `hidden`) avoids creating a
+   scroll container, so position:sticky/fixed descendants keep working. */
+html,
+body {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
 body {
   margin: 0;
   font-family:


### PR DESCRIPTION
## Problem
On mobile, the landing page could be scrolled horizontally — the layout overflowed the viewport width.

## Root cause
The final CTA's decorative background glow was `width: 760px` with `maxWidth: 120vw`, centered with `translate(-50%, -50%)`. The `120vw` made it 10vw wider than the screen on each side, extending the scrollable area.

## Fix
- Clamp the glow to `maxWidth: 100%` and add `overflow: hidden` to the CTA section so it can never bleed past its bounds.
- Add a global guard — `html, body { max-width: 100%; overflow-x: clip }` plus `overflow-x: clip` on the landing root. Using **`clip`** (not `hidden`) avoids creating a scroll container, so `position: sticky` (header) and the `position: fixed` 3D canvas keep working.

## Testing
- `CI=false npm run build` compiles clean; `npm run format` exits 0.
- No element exceeds the viewport width; page no longer scrolls sideways on mobile, and the sticky header + fixed 3D background still behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)