### PR TITLE
Add Three.js, React Three Fiber, and WebGL chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,9 @@
                         <span class="marquee-chip">☕ Java 11</span>
                         <span class="marquee-chip">🍃 Spring Boot</span>
                         <span class="marquee-chip">🐬 MySQL</span>
+                        <span class="marquee-chip">🎮 Three.js</span>
+                        <span class="marquee-chip">🧩 React Three Fiber</span>
+                        <span class="marquee-chip">🌐 WebGL</span>
                         <span class="marquee-chip">🐳 Docker</span>
                         <span class="marquee-chip">☸️ Kubernetes</span>
                         <span class="marquee-chip">🔧 Jenkins CI/CD</span>
@@ -166,6 +169,9 @@
                         <span class="marquee-chip">☕ Java 11</span>
                         <span class="marquee-chip">🍃 Spring Boot</span>
                         <span class="marquee-chip">🐬 MySQL</span>
+                        <span class="marquee-chip">🎮 Three.js</span>
+                        <span class="marquee-chip">🧩 React Three Fiber</span>
+                        <span class="marquee-chip">🌐 WebGL</span>
                         <span class="marquee-chip">🐳 Docker</span>
                         <span class="marquee-chip">☸️ Kubernetes</span>
                         <span class="marquee-chip">🔧 Jenkins CI/CD</span>


### PR DESCRIPTION
This pull request updates the technology stack display in the `index.html` file to highlight additional frontend technologies used in the project. The main change is the addition of Three.js, React Three Fiber, and WebGL to the list of marquee chips shown on the homepage.

**Enhancements to technology stack display:**

* Added `Three.js`, `React Three Fiber`, and `WebGL` as marquee chips to the technology stack section in `index.html`, making the use of advanced 3D and WebGL technologies more visible to users. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R150-R152) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R172-R174)