### PR TITLE
test(frontend): comprehensive snapshot tests for all screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,16 @@ To run tests for the frontend application, use the following command:
 npm test
 ```
 
+The frontend uses **Jest** + **React Testing Library**. Alongside the behavioral suites, every screen has a **snapshot test** under `frontend/__tests__/snapshots/` (one file per screen — Landing, Login, Register, Reset Password, Verify Username, Dashboard, Employee List/Form, Department List/Form, New Department, Profile, Passkeys, Not Found, Quick Actions, Navbar, Footer). Each renders the component with the providers it needs (router, mocked services) and asserts the rendered markup with `toMatchSnapshot()`, so unintended UI changes surface as a diff. The snapshots are deterministic — the 3D hero and charts are stubbed, `autoFocus` is neutralized, `Date` is frozen where rendered, and data fetches are mocked — so they pass identically on local machines and CI regardless of timezone or run time.
+
+```bash
+# Run only the snapshot suites
+npm test -- __tests__/snapshots
+
+# Update the baselines after an intentional UI change, then commit the .snap files
+npm test -- -u
+```
+
 **NOTE: You might need different IDEs for the backend and the frontend. FYI, I used IntelliJ IDEA for the backend and Webstorm for the frontend.**
 
 ## Detailed Component Instructions

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,6 +124,21 @@ npm test
 
 This will start the test runner and execute your test cases.
 
+Tests run on **Jest** + **React Testing Library** and live in `__tests__/`:
+
+- **Behavioral suites** exercise interactions on the core screens (Dashboard, Employee/Department lists, Login, Register, Profile, passkeys).
+- **Snapshot suites** (`__tests__/snapshots/`) lock in the rendered markup of **every screen** — Landing, the auth pages, the dashboard, the employee/department list & form pages, Profile, Passkeys, Not Found, Quick Actions, Navbar, and Footer — asserting each with `toMatchSnapshot()`.
+
+The snapshots are made deterministic (3D hero + charts stubbed, `autoFocus` neutralized, `Date` frozen where rendered, services mocked) so they pass identically on local machines and CI regardless of timezone or when they run.
+
+```bash
+# Run only the snapshot suites
+npm test -- __tests__/snapshots
+
+# Update snapshots after an intentional UI change, then commit the .snap files
+npm test -- -u
+```
+
 ## Detailed Component Instructions
 
 ### `Dashboard.js`

--- a/frontend/__tests__/snapshots/Dashboard.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Dashboard.snapshot.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Charts need a real canvas/GPU; stub them so the snapshot is deterministic.
+jest.mock('react-chartjs-2', () => ({
+  Bar: () => <div data-testid="bar-chart" />,
+  Pie: () => <div data-testid="pie-chart" />,
+  Line: () => <div data-testid="line-chart" />,
+}));
+
+// Keep data fetches pending so the page renders its deterministic loading
+// state with no network and no async act races.
+jest.mock('../../src/services/employeeService', () => ({
+  getAllEmployees: () => new Promise(() => {}),
+  getEmployeeById: () => new Promise(() => {}),
+  addEmployee: jest.fn(),
+  updateEmployee: jest.fn(),
+  deleteEmployee: jest.fn(),
+}));
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+jest.mock('../../src/services/authService', () => ({
+  getToken: () => null,
+  getUsername: () => '',
+  isAuthenticated: () => false,
+  setSession: jest.fn(),
+  clearSession: jest.fn(),
+  subscribeAuth: () => () => {},
+}));
+
+import Dashboard from '../../src/components/Dashboard';
+
+describe('Dashboard snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/DepartmentForm.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/DepartmentForm.snapshot.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+
+import DepartmentForm from '../../src/components/DepartmentForm';
+
+describe('DepartmentForm snapshot', () => {
+  it('matches the rendered markup (add mode)', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/departments/new']}>
+        <Routes>
+          <Route path="/departments/new" element={<DepartmentForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/DepartmentList.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/DepartmentList.snapshot.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+
+import DepartmentList from '../../src/components/DepartmentList';
+
+describe('DepartmentList snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/departments']}>
+        <DepartmentList />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/EmployeeForm.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/EmployeeForm.snapshot.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+jest.mock('../../src/services/employeeService', () => ({
+  getAllEmployees: () => new Promise(() => {}),
+  getEmployeeById: () => new Promise(() => {}),
+  addEmployee: jest.fn(),
+  updateEmployee: jest.fn(),
+  deleteEmployee: jest.fn(),
+}));
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+
+import EmployeeForm from '../../src/components/EmployeeForm';
+
+describe('EmployeeForm snapshot', () => {
+  it('matches the rendered markup (add mode)', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/employees/new']}>
+        <Routes>
+          <Route path="/employees/new" element={<EmployeeForm />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/EmployeeList.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/EmployeeList.snapshot.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/employeeService', () => ({
+  getAllEmployees: () => new Promise(() => {}),
+  getEmployeeById: () => new Promise(() => {}),
+  addEmployee: jest.fn(),
+  updateEmployee: jest.fn(),
+  deleteEmployee: jest.fn(),
+}));
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+
+import EmployeeList from '../../src/components/EmployeeList';
+
+describe('EmployeeList snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/employees']}>
+        <EmployeeList />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Footer.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Footer.snapshot.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Footer from '../../src/components/Footer';
+
+// Footer renders `© {new Date().getFullYear()}`, so freeze "now" to keep the
+// snapshot stable across years/runs.
+const RealDate = Date;
+const FIXED_ISO = '2024-06-15T12:00:00.000Z';
+
+beforeAll(() => {
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      super(...(args.length ? args : [FIXED_ISO]));
+    }
+    static now() {
+      return new RealDate(FIXED_ISO).getTime();
+    }
+  };
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+describe('Footer snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/LandingPage.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/LandingPage.snapshot.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// The hero is a react-three-fiber/WebGL scene that can't run in jsdom and is
+// nondeterministic; stub it so the LandingPage snapshot is stable.
+jest.mock('../../src/components/hero3d/HeroBackground', () => () => (
+  <div data-testid="hero-background-mock" />
+));
+
+import LandingPage from '../../src/components/LandingPage';
+
+describe('LandingPage snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Login.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Login.snapshot.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/authService', () => ({
+  getToken: () => null,
+  getUsername: () => '',
+  isAuthenticated: () => false,
+  setSession: jest.fn(),
+  clearSession: jest.fn(),
+  subscribeAuth: () => () => {},
+}));
+
+jest.mock('../../src/services/passkeyService', () => ({
+  loginWithPasskey: jest.fn(),
+  getApiErrorMessage: () => 'error',
+  startPasskeyAuthentication: jest.fn(),
+  finishPasskeyAuthentication: jest.fn(),
+}));
+
+import Login from '../../src/components/Login';
+
+describe('Login snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Login />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Navbar.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Navbar.snapshot.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/authService', () => ({
+  getToken: () => null,
+  getUsername: () => '',
+  isAuthenticated: () => false,
+  setSession: jest.fn(),
+  clearSession: jest.fn(),
+  subscribeAuth: () => () => {},
+}));
+
+import Navbar from '../../src/components/Navbar';
+
+describe('Navbar snapshot', () => {
+  it('matches the rendered markup (signed out)', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/NewDepartmentForm.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/NewDepartmentForm.snapshot.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+
+import NewDepartmentForm from '../../src/components/NewDepartmentForm';
+
+describe('NewDepartmentForm snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/departments/create']}>
+        <NewDepartmentForm />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/NotFoundPage.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/NotFoundPage.snapshot.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NotFoundPage from '../../src/components/NotFoundPage';
+
+describe('NotFoundPage snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/nope']}>
+        <NotFoundPage />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Passkeys.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Passkeys.snapshot.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Keep the passkey list pending so the page renders its deterministic loading
+// state with no network/WebAuthn dependency.
+jest.mock('../../src/services/passkeyService', () => ({
+  getPasskeys: () => new Promise(() => {}),
+  registerNewPasskey: jest.fn(),
+  renamePasskey: jest.fn(),
+  deletePasskey: jest.fn(),
+  loginWithPasskey: jest.fn(),
+  getApiErrorMessage: () => 'error',
+  startPasskeyRegistration: jest.fn(),
+  finishPasskeyRegistration: jest.fn(),
+  startPasskeyAuthentication: jest.fn(),
+  finishPasskeyAuthentication: jest.fn(),
+}));
+
+import Passkeys from '../../src/components/Passkeys';
+
+describe('Passkeys snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/passkeys']}>
+        <Passkeys />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Profile.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Profile.snapshot.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/employeeService', () => ({
+  getAllEmployees: () => new Promise(() => {}),
+  getEmployeeById: () => new Promise(() => {}),
+  addEmployee: jest.fn(),
+  updateEmployee: jest.fn(),
+  deleteEmployee: jest.fn(),
+}));
+jest.mock('../../src/services/departmentService', () => ({
+  getAllDepartments: () => new Promise(() => {}),
+  getDepartmentById: () => new Promise(() => {}),
+  addDepartment: jest.fn(),
+  updateDepartment: jest.fn(),
+  deleteDepartment: jest.fn(),
+}));
+jest.mock('../../src/services/authService', () => ({
+  getToken: () => null,
+  getUsername: () => '',
+  isAuthenticated: () => false,
+  setSession: jest.fn(),
+  clearSession: jest.fn(),
+  subscribeAuth: () => () => {},
+}));
+
+import Profile from '../../src/components/Profile';
+
+describe('Profile snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/profile']}>
+        <Profile />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/QuickActions.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/QuickActions.snapshot.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import QuickActions from '../../src/components/QuickActions';
+
+describe('QuickActions snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <QuickActions />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/Register.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/Register.snapshot.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('../../src/services/authService', () => ({
+  getToken: () => null,
+  getUsername: () => '',
+  isAuthenticated: () => false,
+  setSession: jest.fn(),
+  clearSession: jest.fn(),
+  subscribeAuth: () => () => {},
+}));
+
+import Register from '../../src/components/Register';
+
+describe('Register snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/register']}>
+        <Register />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/ResetPassword.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/ResetPassword.snapshot.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPassword from '../../src/components/ResetPassword';
+
+describe('ResetPassword snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/reset-password']}>
+        <ResetPassword />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/VerifyUsername.snapshot.test.jsx
+++ b/frontend/__tests__/snapshots/VerifyUsername.snapshot.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VerifyUsername from '../../src/components/VerifyUsername';
+
+describe('VerifyUsername snapshot', () => {
+  it('matches the rendered markup', () => {
+    const { asFragment } = render(
+      <MemoryRouter initialEntries={['/verify-username']}>
+        <VerifyUsername />
+      </MemoryRouter>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/__tests__/snapshots/__snapshots__/Dashboard.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Dashboard.snapshot.test.jsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dashboard snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    aria-live="polite"
+    class="MuiBox-root css-ro5hys"
+    role="status"
+  >
+    <span
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary  css-1yonwsg-MuiCircularProgress-root"
+      role="progressbar"
+      style="width: 40px; height: 40px;"
+    >
+      <svg
+        class="MuiCircularProgress-svg  css-1idz92c-MuiCircularProgress-svg"
+        viewBox="22 22 44 44"
+      >
+        <circle
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate  css-1a8epmm-MuiCircularProgress-circle"
+          cx="44"
+          cy="44"
+          fill="none"
+          r="20.2"
+          stroke-width="3.6"
+        />
+      </svg>
+    </span>
+    <p
+      class="MuiTypography-root MuiTypography-body1  css-183dute-MuiTypography-root"
+    >
+      Crunching the latest org data…
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/DepartmentForm.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/DepartmentForm.snapshot.test.jsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DepartmentForm snapshot matches the rendered markup (add mode) 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-nx8n6e"
+  >
+    <form
+      class="MuiBox-root css-yt6ksr"
+    >
+      <h2>
+        Add Department
+      </h2>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary Mui-required  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for=":r0:"
+          id=":r0:-label"
+        >
+          Department Name
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk   css-wgai2y-MuiFormLabel-asterisk"
+          >
+             *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":r0:"
+            name="name"
+            required=""
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1pbc52w"
+            >
+              <span>
+                Department Name *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary  css-joibnn-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="submit"
+      >
+        Save
+      </button>
+    </form>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/DepartmentList.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/DepartmentList.snapshot.test.jsx.snap
@@ -1,0 +1,467 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DepartmentList snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <div
+      class="MuiSnackbar-root MuiSnackbar-anchorOriginTopCenter  css-ikhur5-MuiSnackbar-root"
+      role="presentation"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard  css-6ecq4l-MuiPaper-root-MuiAlert-root"
+        direction="down"
+        role="alert"
+        style="--Paper-shadow: none; opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      >
+        <div
+          class="MuiAlert-icon  css-1ytlwq5-MuiAlert-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit  css-1lzspe0-MuiSvgIcon-root"
+            data-testid="ReportProblemOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAlert-message  css-1pxa9xg-MuiAlert-message"
+        >
+          You must be logged in to access the department list. 
+          <span
+            style="color: rgb(63, 81, 181); text-decoration: underline; cursor: pointer; transition: color 0.1s;"
+          >
+            Login
+          </span>
+        </div>
+        <div
+          class="MuiAlert-action  css-ki1hdl-MuiAlert-action"
+        >
+          <button
+            aria-label="Close"
+            class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall  css-18qjhy-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall  css-18w7uxr-MuiSvgIcon-root"
+              data-testid="CloseIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root  css-1ipo5lz-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4  css-jq85n-MuiTypography-root"
+        >
+          Departments
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1  css-h6r3vf-MuiTypography-root"
+        >
+          Organize teams with quick filters, exports, and at-a-glance stats.
+        </p>
+      </div>
+      <div
+        class="MuiStack-root  css-niqf4j-MuiStack-root"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary  css-1imukh4-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Export CSV
+        </button>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary  css-142372x-MuiButtonBase-root-MuiButton-root"
+          href="/add-department"
+          tabindex="0"
+        >
+          Add Department
+        </a>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2  css-l8v5xp-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-19am722-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Total departments
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            0
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            Across your organization
+          </span>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1x96s5q-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Visible now
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            0
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            Matching search
+          </span>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1bhi72i-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Quick actions
+          </p>
+          <div
+            class="MuiStack-root  css-1v92mdz-MuiStack-root"
+          >
+            <a
+              class="MuiButtonBase-root  MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary  css-1u6jax8-MuiButtonBase-root-MuiChip-root"
+              href="/add-department"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium  css-6od3lo-MuiChip-label"
+              >
+                Add dept
+              </span>
+            </a>
+            <a
+              class="MuiButtonBase-root  MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault  css-sg2e8q-MuiButtonBase-root-MuiChip-root"
+              href="/employees"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium  css-6od3lo-MuiChip-label"
+              >
+                View employees
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1tlmmqv-MuiPaper-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiStack-root  css-1sazv7p-MuiStack-root"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="false"
+            for=":r0:"
+            id=":r0:-label"
+          >
+            Search for a department
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r0:"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1pbc52w"
+              >
+                <span>
+                  Search for a department
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiStack-root  css-1i67jkc-MuiStack-root"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  css-1b5lkxe-MuiFormControl-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary MuiFormLabel-filled  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-18pjc51-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              id="sort-dept-label"
+            >
+              Sort by
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-formControl   css-1cprn2g-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            >
+              <div
+                aria-controls=":r1:"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="sort-dept-label"
+                class="MuiSelect-select MuiSelect-outlined  MuiInputBase-input MuiOutlinedInput-input   css-15k6ek6-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                role="combobox"
+                tabindex="0"
+              >
+                Name A-Z
+              </div>
+              <input
+                aria-hidden="true"
+                aria-invalid="false"
+                class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+                tabindex="-1"
+                value="asc"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiSelect-iconOutlined  css-1u6jos5-MuiSvgIcon-root-MuiSelect-icon"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-kg5swy"
+                >
+                  <span>
+                    Sort by
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd  css-j204z7-MuiFormControlLabel-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium  css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary   PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary   css-byenzh-MuiButtonBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  class="PrivateSwitchBase-input MuiSwitch-input   css-1m9pwf3"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb  css-jsexje-MuiSwitch-thumb"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track  css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-body1  MuiFormControlLabel-label  css-1edfpdg-MuiTypography-root"
+            >
+              Compact rows
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiTableContainer-root  css-1qw7of0-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root  css-rqglhn-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root  css-15wwp11-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head  css-q1udx3-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Name
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              ID
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeMedium  css-x3a2al-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root  css-apqrd9-MuiTableBody-root"
+        />
+      </table>
+    </div>
+    <div
+      class="MuiTablePagination-root  css-jtlhu6-MuiTablePagination-root"
+    >
+      <div
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular  MuiTablePagination-toolbar  css-16og44m-MuiToolbar-root-MuiTablePagination-toolbar"
+      >
+        <div
+          class="MuiTablePagination-spacer  css-1psng7p-MuiTablePagination-spacer"
+        />
+        <p
+          class="MuiTablePagination-selectLabel  css-pdct74-MuiTablePagination-selectLabel"
+          id=":r3:"
+        >
+          Rows per page:
+        </p>
+        <div
+          class="MuiInputBase-root MuiInputBase-colorPrimary  MuiTablePagination-input  css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+        >
+          <div
+            aria-controls=":r4:"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby=":r3: :r2:"
+            class="MuiSelect-select MuiTablePagination-select  MuiSelect-standard  MuiInputBase-input  css-141c2s2-MuiSelect-select-MuiInputBase-input"
+            id=":r2:"
+            role="combobox"
+            tabindex="0"
+          >
+            5
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="5"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiTablePagination-selectIcon  MuiSelect-iconStandard  css-rm9hue-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+        <p
+          class="MuiTablePagination-displayedRows  css-levciy-MuiTablePagination-displayedRows"
+        >
+          0–0 of 0
+        </p>
+        <div
+          class="MuiTablePagination-actions "
+        >
+          <button
+            aria-label="Go to previous page"
+            class="MuiButtonBase-root Mui-disabled  MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium  css-1kcqes5-MuiButtonBase-root-MuiIconButton-root"
+            disabled=""
+            tabindex="-1"
+            title="Go to previous page"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowLeftIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="Go to next page"
+            class="MuiButtonBase-root Mui-disabled  MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium  css-1kcqes5-MuiButtonBase-root-MuiIconButton-root"
+            disabled=""
+            tabindex="-1"
+            title="Go to next page"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/EmployeeForm.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/EmployeeForm.snapshot.test.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmployeeForm snapshot matches the rendered markup (add mode) 1`] = `
+<DocumentFragment>
+  <div
+    class="css-1lb6n3v"
+  >
+    <span
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary  css-1yonwsg-MuiCircularProgress-root"
+      role="progressbar"
+      style="width: 40px; height: 40px;"
+    >
+      <svg
+        class="MuiCircularProgress-svg  css-1idz92c-MuiCircularProgress-svg"
+        viewBox="22 22 44 44"
+      >
+        <circle
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate  css-1a8epmm-MuiCircularProgress-circle"
+          cx="44"
+          cy="44"
+          fill="none"
+          r="20.2"
+          stroke-width="3.6"
+        />
+      </svg>
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/EmployeeList.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/EmployeeList.snapshot.test.jsx.snap
@@ -1,0 +1,645 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmployeeList snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <div
+      class="MuiSnackbar-root MuiSnackbar-anchorOriginTopCenter  css-ikhur5-MuiSnackbar-root"
+      role="presentation"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard  css-6ecq4l-MuiPaper-root-MuiAlert-root"
+        direction="down"
+        role="alert"
+        style="--Paper-shadow: none; opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      >
+        <div
+          class="MuiAlert-icon  css-1ytlwq5-MuiAlert-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit  css-1lzspe0-MuiSvgIcon-root"
+            data-testid="ReportProblemOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAlert-message  css-1pxa9xg-MuiAlert-message"
+        >
+          You must be logged in to access the employee list. 
+          <span
+            style="color: rgb(63, 81, 181); text-decoration: underline; cursor: pointer; transition: color 0.1s;"
+          >
+            Login
+          </span>
+        </div>
+        <div
+          class="MuiAlert-action  css-ki1hdl-MuiAlert-action"
+        >
+          <button
+            aria-label="Close"
+            class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall  css-18qjhy-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall  css-18w7uxr-MuiSvgIcon-root"
+              data-testid="CloseIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root  css-1ipo5lz-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4  css-jq85n-MuiTypography-root"
+        >
+          Employees
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1  css-h6r3vf-MuiTypography-root"
+        >
+          Search, filter, and export your directory without leaving the page.
+        </p>
+      </div>
+      <div
+        class="MuiStack-root  css-niqf4j-MuiStack-root"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary  css-1imukh4-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Export CSV
+        </button>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary  css-142372x-MuiButtonBase-root-MuiButton-root"
+          href="/add-employee"
+          tabindex="0"
+        >
+          Add Employee
+        </a>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2  css-l8v5xp-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-19am722-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Total employees
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            0
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            Across all departments
+          </span>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1x96s5q-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Visible now
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            0
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            After filters
+          </span>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1bhi72i-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Departments
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            0
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            Available for assignment
+          </span>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-5ztdbs-MuiPaper-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Avg age
+          </p>
+          <h4
+            class="MuiTypography-root MuiTypography-h4  css-185u8kw-MuiTypography-root"
+          >
+            —
+          </h4>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-mlv3xz-MuiTypography-root"
+          >
+            Across current roster
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  css-1tlmmqv-MuiPaper-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiStack-root  css-1sazv7p-MuiStack-root"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="false"
+            for=":r0:"
+            id=":r0:-label"
+          >
+            Search by name or email...
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r0:"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1pbc52w"
+              >
+                <span>
+                  Search by name or email...
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiStack-root  css-1i67jkc-MuiStack-root"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  css-1b5lkxe-MuiFormControl-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary MuiFormLabel-filled  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-18pjc51-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              id="department-filter-label"
+            >
+              Department
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-formControl   css-1cprn2g-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            >
+              <div
+                aria-controls=":r1:"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="department-filter-label"
+                class="MuiSelect-select MuiSelect-outlined  MuiInputBase-input MuiOutlinedInput-input   css-15k6ek6-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                role="combobox"
+                tabindex="0"
+              >
+                All departments
+              </div>
+              <input
+                aria-hidden="true"
+                aria-invalid="false"
+                class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+                tabindex="-1"
+                value="all"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiSelect-iconOutlined  css-1u6jos5-MuiSvgIcon-root-MuiSelect-icon"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-kg5swy"
+                >
+                  <span>
+                    Department
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  css-1b5lkxe-MuiFormControl-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary MuiFormLabel-filled  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-18pjc51-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              id="age-filter-label"
+            >
+              Age
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-formControl   css-1cprn2g-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            >
+              <div
+                aria-controls=":r2:"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="age-filter-label"
+                class="MuiSelect-select MuiSelect-outlined  MuiInputBase-input MuiOutlinedInput-input   css-15k6ek6-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                role="combobox"
+                tabindex="0"
+              >
+                All ranges
+              </div>
+              <input
+                aria-hidden="true"
+                aria-invalid="false"
+                class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+                tabindex="-1"
+                value="all"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiSelect-iconOutlined  css-1u6jos5-MuiSvgIcon-root-MuiSelect-icon"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-kg5swy"
+                >
+                  <span>
+                    Age
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  css-1b5lkxe-MuiFormControl-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary MuiFormLabel-filled  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-18pjc51-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              id="sort-filter-label"
+            >
+              Sort by
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-formControl   css-1cprn2g-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            >
+              <div
+                aria-controls=":r3:"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="sort-filter-label"
+                class="MuiSelect-select MuiSelect-outlined  MuiInputBase-input MuiOutlinedInput-input   css-15k6ek6-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                role="combobox"
+                tabindex="0"
+              >
+                Name
+              </div>
+              <input
+                aria-hidden="true"
+                aria-invalid="false"
+                class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+                tabindex="-1"
+                value="name"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiSelect-iconOutlined  css-1u6jos5-MuiSvgIcon-root-MuiSelect-icon"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-kg5swy"
+                >
+                  <span>
+                    Sort by
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiStack-root  css-6drtjh-MuiStack-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+          >
+            Active filters:
+          </p>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary  css-8iab9z-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Reset
+          </button>
+          <label
+            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd  css-j204z7-MuiFormControlLabel-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium  css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary   PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary   css-byenzh-MuiButtonBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  class="PrivateSwitchBase-input MuiSwitch-input   css-1m9pwf3"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb  css-jsexje-MuiSwitch-thumb"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track  css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-body1  MuiFormControlLabel-label  css-1edfpdg-MuiTypography-root"
+            >
+              Compact rows
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiTableContainer-root  css-1qw7of0-MuiPaper-root-MuiTableContainer-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <table
+        class="MuiTable-root  css-rqglhn-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root  css-15wwp11-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head  css-q1udx3-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Employee
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Email
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Department
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Age
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium  css-3qpjqv-MuiTableCell-root"
+              scope="col"
+            >
+              Contact
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeMedium  css-x3a2al-MuiTableCell-root"
+              scope="col"
+            >
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root  css-apqrd9-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root  css-1q1u3t4-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium  css-10ukr6t-MuiTableCell-root"
+              colspan="6"
+            >
+              <div
+                class="MuiBox-root css-1pg69xh"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1  css-1ixrkmk-MuiTypography-root"
+                >
+                  No employees match your filters.
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2  css-atovpb-MuiTypography-root"
+                >
+                  Try broadening your filters or add a new employee to get started.
+                </p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="MuiTablePagination-root  css-jtlhu6-MuiTablePagination-root"
+    >
+      <div
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular  MuiTablePagination-toolbar  css-16og44m-MuiToolbar-root-MuiTablePagination-toolbar"
+      >
+        <div
+          class="MuiTablePagination-spacer  css-1psng7p-MuiTablePagination-spacer"
+        />
+        <p
+          class="MuiTablePagination-selectLabel  css-pdct74-MuiTablePagination-selectLabel"
+          id=":r5:"
+        >
+          Rows per page:
+        </p>
+        <div
+          class="MuiInputBase-root MuiInputBase-colorPrimary  MuiTablePagination-input  css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+        >
+          <div
+            aria-controls=":r6:"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby=":r5: :r4:"
+            class="MuiSelect-select MuiTablePagination-select  MuiSelect-standard  MuiInputBase-input  css-141c2s2-MuiSelect-select-MuiInputBase-input"
+            id=":r4:"
+            role="combobox"
+            tabindex="0"
+          >
+            5
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput  css-yf8vq0-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="5"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSelect-icon MuiTablePagination-selectIcon  MuiSelect-iconStandard  css-rm9hue-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+        </div>
+        <p
+          class="MuiTablePagination-displayedRows  css-levciy-MuiTablePagination-displayedRows"
+        >
+          0–0 of 0
+        </p>
+        <div
+          class="MuiTablePagination-actions "
+        >
+          <button
+            aria-label="Go to previous page"
+            class="MuiButtonBase-root Mui-disabled  MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium  css-1kcqes5-MuiButtonBase-root-MuiIconButton-root"
+            disabled=""
+            tabindex="-1"
+            title="Go to previous page"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowLeftIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="Go to next page"
+            class="MuiButtonBase-root Mui-disabled  MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium  css-1kcqes5-MuiButtonBase-root-MuiIconButton-root"
+            disabled=""
+            tabindex="-1"
+            title="Go to next page"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Footer.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Footer.snapshot.test.jsx.snap
@@ -1,0 +1,143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <footer
+    class="MuiBox-root css-ix2xpx"
+  >
+    <div
+      class="MuiBox-root css-1inxg8x"
+    />
+    <div
+      class="MuiBox-root css-1ssx4aj"
+    />
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthLg  css-5c1adp-MuiContainer-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4  css-480o17-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+        >
+          <h6
+            class="MuiTypography-root MuiTypography-h6  css-jho08z-MuiTypography-root"
+          >
+            About Us
+          </h6>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            We provide a comprehensive Employee Management System that helps you manage your employees and departments with ease. Our mission is to make HR processes seamless and efficient.
+          </p>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+        >
+          <h6
+            class="MuiTypography-root MuiTypography-h6  css-jho08z-MuiTypography-root"
+          >
+            Quick Links
+          </h6>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/"
+            >
+              Home
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/dashboard"
+            >
+              Dashboard
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/employees"
+            >
+              Employees
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/departments"
+            >
+              Departments
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/profile"
+            >
+              Profile
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-1ty68i9-MuiTypography-root-MuiLink-root"
+              href="/login"
+            >
+              Login
+            </a>
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineNone  css-18xdus5-MuiTypography-root-MuiLink-root"
+              href="/register"
+            >
+              Register
+            </a>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+        >
+          <h6
+            class="MuiTypography-root MuiTypography-h6  css-jho08z-MuiTypography-root"
+          >
+            Contact Us
+          </h6>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            Project Maintainer: 
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineAlways  css-1hun5y9-MuiTypography-root-MuiLink-root"
+              href="https://github.com/hoangsonww"
+            >
+              Son Nguyen
+            </a>
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            Email: 
+            <a
+              class="MuiTypography-root MuiTypography-inherit  MuiLink-root MuiLink-underlineAlways  css-1hun5y9-MuiTypography-root-MuiLink-root"
+              href="mailto:hoangson091104@gmail.com"
+            >
+              hoangson091104@gmail.com
+            </a>
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            Phone: +1 (123) 456-7890
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1c1tih0-MuiTypography-root"
+          >
+            Address: 123 Employee St, Suite 100, New York, NY 10001
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-vqz7cl"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+        >
+          © 2024 Employee Management System. All rights reserved.
+        </p>
+      </div>
+    </div>
+  </footer>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
@@ -1,0 +1,2442 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LandingPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-7rylf6"
+  >
+    <div
+      data-testid="hero-background-mock"
+    />
+    <div
+      class="MuiBox-root css-rqgsqp"
+    >
+      <header
+        class="MuiBox-root css-ie89po"
+      >
+        <div
+          class="MuiContainer-root MuiContainer-maxWidthLg  css-1bbbwhe-MuiContainer-root"
+        >
+          <div
+            class="MuiStack-root  css-v0rvj0-MuiStack-root"
+          >
+            <a
+              class="MuiStack-root  css-1lcy74e-MuiStack-root"
+              href="/"
+            >
+              <div
+                class="MuiBox-root css-1ggwps9"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-jslvge-MuiSvgIcon-root"
+                  data-testid="HubIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.4 18.2c.38.5.6 1.12.6 1.8 0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3c.44 0 .85.09 1.23.26l1.41-1.77c-.92-1.03-1.29-2.39-1.09-3.69l-2.03-.68c-.54.83-1.46 1.38-2.52 1.38-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3c0 .07 0 .14-.01.21l2.03.68c.64-1.21 1.82-2.09 3.22-2.32V5.91C9.96 5.57 9 4.4 9 3c0-1.66 1.34-3 3-3s3 1.34 3 3c0 1.4-.96 2.57-2.25 2.91v2.16c1.4.23 2.58 1.11 3.22 2.32L18 9.71V9.5c0-1.66 1.34-3 3-3s3 1.34 3 3-1.34 3-3 3c-1.06 0-1.98-.55-2.52-1.37l-2.03.68c.2 1.29-.16 2.65-1.09 3.69l1.41 1.77Q17.34 17 18 17c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3c0-.68.22-1.3.6-1.8l-1.41-1.77c-1.35.75-3.01.76-4.37 0z"
+                  />
+                </svg>
+              </div>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-19g256p-MuiTypography-root"
+              >
+                Employee
+                <span
+                  class="MuiBox-root css-1cv996i"
+                >
+                  OS
+                </span>
+              </p>
+            </a>
+            <button
+              aria-label="Open menu"
+              class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-sizeMedium  css-g37jwq-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                data-testid="MenuIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 18h18v-2H3zm0-5h18v-2H3zm0-7v2h18V6z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </header>
+      <section
+        class="MuiBox-root css-1bya5ds"
+        id="top"
+      >
+        <div
+          class="MuiContainer-root MuiContainer-maxWidthLg  css-h9jbmk-MuiContainer-root"
+        >
+          <div
+            class="MuiBox-root css-y3ly9k"
+          >
+            <div
+              class="MuiBox-root css-1ufn0tk"
+            >
+              <div
+                class="MuiBox-root css-1ezo8v8"
+              />
+              <span
+                class="MuiTypography-root MuiTypography-overline  css-iho1ru-MuiTypography-root"
+              >
+                EMPLOYEE MANAGEMENT PLATFORM
+              </span>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1n97ixy"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-body1  css-1q4pka4-MuiTypography-root"
+            >
+              Run your workforce with 
+              <span
+                class="MuiBox-root css-1cv996i"
+              >
+                clarity & confidence
+              </span>
+              .
+            </h1>
+          </div>
+          <div
+            class="MuiBox-root css-53wtt7"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1  css-tqid57-MuiTypography-root"
+            >
+              One place for dashboards, departments, and people operations — built for teams that need insights, not spreadsheets.
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-1tbj7ts"
+          >
+            <div
+              class="MuiStack-root  css-sjlbam-MuiStack-root"
+            >
+              <a
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary  css-196xvcv-MuiButtonBase-root-MuiButton-root"
+                href="/dashboard"
+                tabindex="0"
+              >
+                <span
+                  class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge  css-hev6se-MuiButton-startIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="SpaceDashboardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 21H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h6zm2 0h6c1.1 0 2-.9 2-2v-7h-8zm8-11V5c0-1.1-.9-2-2-2h-6v7z"
+                    />
+                  </svg>
+                </span>
+                View Dashboard
+              </a>
+              <a
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary  css-5etw3k-MuiButtonBase-root-MuiButton-root"
+                href="/employees"
+                tabindex="0"
+              >
+                <span
+                  class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge  css-hev6se-MuiButton-startIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="PeopleAltIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.67 13.13C18.04 14.06 19 15.32 19 17v3h4v-3c0-2.18-3.57-3.47-6.33-3.87"
+                      fill-rule="evenodd"
+                    />
+                    <circle
+                      cx="9"
+                      cy="8"
+                      fill-rule="evenodd"
+                      r="4"
+                    />
+                    <path
+                      d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4c-.47 0-.91.1-1.33.24C14.5 5.27 15 6.58 15 8s-.5 2.73-1.33 3.76c.42.14.86.24 1.33.24m-6 1c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                Browse Directory
+              </a>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary  css-18071m-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                Learn More
+                <span
+                  class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeLarge  css-3155yg-MuiButton-endIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1rm90m3"
+          >
+            <div
+              class="MuiStack-root  css-14q4ayq-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-bfkyfa"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                  data-testid="CheckCircleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                  />
+                </svg>
+                <p
+                  class="MuiTypography-root MuiTypography-body2  css-1823vqr-MuiTypography-root"
+                >
+                  Faster onboarding
+                </p>
+              </div>
+              <div
+                class="MuiBox-root css-bfkyfa"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                  data-testid="CheckCircleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                  />
+                </svg>
+                <p
+                  class="MuiTypography-root MuiTypography-body2  css-1823vqr-MuiTypography-root"
+                >
+                  Role-based access
+                </p>
+              </div>
+              <div
+                class="MuiBox-root css-bfkyfa"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                  data-testid="CheckCircleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                  />
+                </svg>
+                <p
+                  class="MuiTypography-root MuiTypography-body2  css-1823vqr-MuiTypography-root"
+                >
+                  Export-ready data
+                </p>
+              </div>
+              <div
+                class="MuiBox-root css-bfkyfa"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                  data-testid="CheckCircleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                  />
+                </svg>
+                <p
+                  class="MuiTypography-root MuiTypography-body2  css-1823vqr-MuiTypography-root"
+                >
+                  Insightful dashboards
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-12r70nr"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1lybsbv-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4  css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-867b0l"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1  css-15uyqxo-MuiTypography-root"
+                  >
+                    <span
+                      class="MuiBox-root css-y4yuzd"
+                    >
+                      0.00%
+                    </span>
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-e57jjl-MuiTypography-root"
+                  >
+                    Data uptime in the last 12 months
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4  css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-867b0l"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1  css-15uyqxo-MuiTypography-root"
+                  >
+                    <span
+                      class="MuiBox-root css-y4yuzd"
+                    >
+                      0.0 min
+                    </span>
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-e57jjl-MuiTypography-root"
+                  >
+                    Average export turnaround
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4  css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-867b0l"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1  css-15uyqxo-MuiTypography-root"
+                  >
+                    <span
+                      class="MuiBox-root css-y4yuzd"
+                    >
+                      0.0x
+                    </span>
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-e57jjl-MuiTypography-root"
+                  >
+                    Faster approvals for managers
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1chm7qp"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-14ctfxt-MuiTypography-root"
+          >
+            SCROLL
+          </span>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+            data-testid="KeyboardArrowDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+            />
+          </svg>
+        </div>
+      </section>
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg  css-1bbbwhe-MuiContainer-root"
+      >
+        <div
+          class="MuiBox-root css-u1oynh"
+          id="trusted"
+        >
+          <div
+            class="MuiBox-root css-y3ly9k"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1  css-1wvjhem-MuiTypography-root"
+            >
+              Trusted by teams that care about clarity
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-vgl9sc"
+          >
+            <div
+              class="MuiBox-root css-hfg0o8"
+            >
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Atlas HR
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Northwind Ops
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Acme Labs
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Cobalt Systems
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                HelioCo
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Vertex Group
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Lumen Works
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Atlas HR
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Northwind Ops
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Acme Labs
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Cobalt Systems
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                HelioCo
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Vertex Group
+              </div>
+              <div
+                class="MuiBox-root css-rfh7of"
+              >
+                Lumen Works
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-4jc6d9"
+          id="operational-benchmarks"
+        >
+          <div
+            class="MuiBox-root css-11xhw5n"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                By the numbers
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                Operational benchmarks at a glance
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-z1c735-MuiTypography-root"
+              >
+                A single source of truth translates into measurable outcomes. These benchmarks reflect the operational scale the platform is designed to support.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1p0uuab-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0+
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Active employee records
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Consolidated across divisions and locations.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-5ktv1l"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Departments organized
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Clear ownership, headcount, and budgets.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-53wtt7"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0.0 hrs
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Average onboarding cycle
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      From invite to day-one readiness.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0 mo
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Rolling audit history
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Structured logs ready for review.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-5ktv1l"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0+
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Weekly exports delivered
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Finance and leadership ready.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-53wtt7"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1nxa4z3-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0.0%
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-d445sl-MuiTypography-root"
+                    >
+                      Roster accuracy
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Validated by automated checks.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <span
+            class="MuiTypography-root MuiTypography-caption  css-1t978lx-MuiTypography-root"
+          >
+            Benchmarks shown are illustrative.
+          </span>
+        </div>
+        <div
+          class="MuiBox-root css-4jc6d9"
+          id="features"
+        >
+          <div
+            class="MuiBox-root css-11xhw5n"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                Everything you need
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                A complete toolkit to operate smoothly
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-z1c735-MuiTypography-root"
+              >
+                From employee profiles to dashboards, every module is designed for fast decisions and confident sharing — no extra tools required.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1p0uuab-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-1kk488r"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-afc4e2"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="PeopleAltIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.67 13.13C18.04 14.06 19 15.32 19 17v3h4v-3c0-2.18-3.57-3.47-6.33-3.87"
+                          fill-rule="evenodd"
+                        />
+                        <circle
+                          cx="9"
+                          cy="8"
+                          fill-rule="evenodd"
+                          r="4"
+                        />
+                        <path
+                          d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4c-.47 0-.91.1-1.33.24C14.5 5.27 15 6.58 15 8s-.5 2.73-1.33 3.76c.42.14.86.24 1.33.24m-6 1c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Employee 360
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Full profiles, quick edits, exports, and smart filters for any slice of your org.
+                    </p>
+                    <a
+                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-5wsez1-MuiButtonBase-root-MuiButton-root"
+                      href="/employees"
+                      tabindex="0"
+                    >
+                      Open
+                      <span
+                        class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium  css-1gulhci-MuiButton-endIcon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                          data-testid="ArrowForwardIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                          />
+                        </svg>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-5ktv1l"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-13trenm"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-loorhh"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="ShieldIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Department clarity
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Keep teams organized with clean structures and quick pivots between units.
+                    </p>
+                    <a
+                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-5wsez1-MuiButtonBase-root-MuiButton-root"
+                      href="/departments"
+                      tabindex="0"
+                    >
+                      Open
+                      <span
+                        class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium  css-1gulhci-MuiButton-endIcon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                          data-testid="ArrowForwardIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                          />
+                        </svg>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-53wtt7"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-1nbi25z"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-o839tm"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Insightful dashboards
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Trend lines, cohorts, and composition charts that show what moves the needle.
+                    </p>
+                    <a
+                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-5wsez1-MuiButtonBase-root-MuiButton-root"
+                      href="/dashboard"
+                      tabindex="0"
+                    >
+                      Open
+                      <span
+                        class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium  css-1gulhci-MuiButton-endIcon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                          data-testid="ArrowForwardIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                          />
+                        </svg>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-1jxfe1v"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-ya3j9x"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="RocketLaunchIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M9.19 6.35c-2.04 2.29-3.44 5.58-3.57 5.89L2 10.69l4.05-4.05c.47-.47 1.15-.68 1.81-.55zM11.17 17s3.74-1.55 5.89-3.7c5.4-5.4 4.5-9.62 4.21-10.57-.95-.3-5.17-1.19-10.57 4.21C8.55 9.09 7 12.83 7 12.83zm6.48-2.19c-2.29 2.04-5.58 3.44-5.89 3.57L13.31 22l4.05-4.05c.47-.47.68-1.15.55-1.81zM9 18c0 .83-.34 1.58-.88 2.12C6.94 21.3 2 22 2 22s.7-4.94 1.88-6.12C4.42 15.34 5.17 15 6 15c1.66 0 3 1.34 3 3m4-9c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Launch updates fast
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Create employees or departments in minutes with guided, validated workflows.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-5ktv1l"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-xrqxer"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-15vrqa1"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="AutoGraphIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M14.06 9.94 12 9l2.06-.94L15 6l.94 2.06L18 9l-2.06.94L15 12zM4 14l.94-2.06L7 11l-2.06-.94L4 8l-.94 2.06L1 11l2.06.94zm4.5-5 1.09-2.41L12 5.5 9.59 4.41 8.5 2 7.41 4.41 5 5.5l2.41 1.09zm-4 11.5 6-6.01 4 4L23 8.93l-1.41-1.41-7.09 7.97-4-4L3 19z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Always in sync
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Charts, filters, and exports all run off the same single source of truth.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4  css-11l5t4l-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-53wtt7"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-9m8c2i-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiBox-root css-1sp6d5q"
+                  />
+                  <div
+                    class="MuiCardContent-root  css-i4n7ey-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-192fruo"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="DevicesIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M4 6h18V4H4c-1.1 0-2 .9-2 2v11H0v3h14v-3H4zm19 2h-6c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1m-1 9h-4v-7h4z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-dedexj-MuiTypography-root"
+                    >
+                      Any device
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-3s1cv7-MuiTypography-root"
+                    >
+                      Responsive layouts keep dashboards and lists usable anywhere you work.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-4jc6d9"
+          id="platform"
+        >
+          <div
+            class="MuiBox-root css-11xhw5n"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                The platform
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                Governance, automation, and reporting
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-z1c735-MuiTypography-root"
+              >
+                Keep sensitive data protected, automate the routine, and deliver leadership-ready insights — all from one connected system.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1p0uuab-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1wjcb4p-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-1n8p2md-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1qf1x51"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="ShieldIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-qwql2q-MuiTypography-root"
+                    >
+                      Security & governance
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-eb9i3x-MuiTypography-root"
+                    >
+                      Teams see what they need while sensitive data stays protected across the org.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1wd5hcn-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Role-based access per department
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Export logs and approval trails
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Data retention controls with reminders
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-gz4wkv"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1wjcb4p-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-1n8p2md-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-b48l94"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="BoltIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66s.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-qwql2q-MuiTypography-root"
+                    >
+                      Process automation
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-eb9i3x-MuiTypography-root"
+                    >
+                      Reduce manual handoffs with task-ready workflows and clear ownership.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1wd5hcn-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          New-hire checklists by team
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Department change alerts
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Manager approval routing
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-v4ilb6"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1wjcb4p-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-1n8p2md-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1ob9tcb"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="AssessmentIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2M9 17H7v-7h2zm4 0h-2V7h2zm4 0h-2v-4h2z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-qwql2q-MuiTypography-root"
+                    >
+                      Executive reporting
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-eb9i3x-MuiTypography-root"
+                    >
+                      Pack leadership updates with consistent metrics and clean summaries.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1wd5hcn-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Headcount and growth mix
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Tenure and age distributions
+                        </p>
+                      </div>
+                      <div
+                        class="MuiStack-root  css-jj9op2-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1nhtwih-MuiSvgIcon-root"
+                          data-testid="CheckCircleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-fqpw1h-MuiTypography-root"
+                        >
+                          Budget-ready department rollups
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-4jc6d9"
+          id="workflow"
+        >
+          <div
+            class="MuiBox-root css-16ieni4"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                How it works
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                Live in three focused steps
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-1kkrn0w-MuiTypography-root"
+              >
+                Set up once, align departments, and publish insights without disrupting the team.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-79elbk"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiBox-root css-tq0mah"
+            />
+            <div
+              class="MuiGrid-root MuiGrid-container  css-1hk5ios-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-y3ly9k"
+                >
+                  <div
+                    class="MuiBox-root css-c34vcg"
+                  >
+                    <div
+                      class="MuiBox-root css-1irg57b"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="VerifiedUserIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5zm-2 16-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9z"
+                        />
+                      </svg>
+                      <div
+                        class="MuiBox-root css-x56qyu"
+                      >
+                        1
+                      </div>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-13nzgwt-MuiTypography-root"
+                    >
+                      Secure access
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-4t85rg-MuiTypography-root"
+                    >
+                      Protected routes and login flows keep sensitive data safe from day one.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-pbmk3v"
+                >
+                  <div
+                    class="MuiBox-root css-c34vcg"
+                  >
+                    <div
+                      class="MuiBox-root css-1irg57b"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="ShieldIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5z"
+                        />
+                      </svg>
+                      <div
+                        class="MuiBox-root css-x56qyu"
+                      >
+                        2
+                      </div>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-13nzgwt-MuiTypography-root"
+                    >
+                      Configure teams
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-4t85rg-MuiTypography-root"
+                    >
+                      Set up departments, import employees, and wire up quick actions.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-1tbj7ts"
+                >
+                  <div
+                    class="MuiBox-root css-c34vcg"
+                  >
+                    <div
+                      class="MuiBox-root css-1irg57b"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                        />
+                      </svg>
+                      <div
+                        class="MuiBox-root css-x56qyu"
+                      >
+                        3
+                      </div>
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-13nzgwt-MuiTypography-root"
+                    >
+                      Share insights
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-4t85rg-MuiTypography-root"
+                    >
+                      Use dashboards and exports to keep leadership aligned every week.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-15izwtl"
+        >
+          <div
+            class="MuiBox-root css-16ieni4"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                Service levels
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                Performance guardrails built for confidence
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-1kkrn0w-MuiTypography-root"
+              >
+                Automation depth and operational coverage designed to keep your people data dependable.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1p0uuab-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1twuozi-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0/7
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-15vd4ve-MuiTypography-root"
+                    >
+                      Monitoring and alerts
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Operational coverage for core workflows.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-5ktv1l"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1twuozi-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0 min
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-15vd4ve-MuiTypography-root"
+                    >
+                      Median response time
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Team notified on critical exceptions.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-53wtt7"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1twuozi-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0 regions
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-15vd4ve-MuiTypography-root"
+                    >
+                      Deployment options
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Support regional data residency needs.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3  css-10voxkt-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-1ap6fsp"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-fyeypj-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-zbr9h2-MuiCardContent-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1twuozi-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-y4yuzd"
+                      >
+                        0+
+                      </span>
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-15vd4ve-MuiTypography-root"
+                    >
+                      Automation rules
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2  css-67y5o6-MuiTypography-root"
+                    >
+                      Built-in triggers for ops playbooks.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-15izwtl"
+        >
+          <div
+            class="MuiBox-root css-11xhw5n"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                Who it's for
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                One data layer, every team aligned
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-z1c735-MuiTypography-root"
+              >
+                People leaders, engineering managers, and operations teams rely on the same trusted data to move fast and stay in sync.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2.5  css-1p0uuab-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-y3ly9k"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1w1rcmw-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-xt5h0d-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-driq9y"
+                    >
+                      “
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1risbja-MuiTypography-root"
+                    >
+                      We went from ad-hoc spreadsheets to instant exports that finance loves.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1hyf038-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault  css-gd2dah-MuiAvatar-root"
+                      >
+                        P
+                      </div>
+                      <div
+                        class="MuiBox-root css-0"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-1oqxamc-MuiTypography-root"
+                        >
+                          People Ops
+                        </p>
+                        <span
+                          class="MuiTypography-root MuiTypography-caption  css-bttn9n-MuiTypography-root"
+                        >
+                          HR Lead
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-1n97ixy"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1w1rcmw-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-xt5h0d-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-driq9y"
+                    >
+                      “
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1risbja-MuiTypography-root"
+                    >
+                      Charts and filters answer headcount questions before they are even asked.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1hyf038-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault  css-gd2dah-MuiAvatar-root"
+                      >
+                        T
+                      </div>
+                      <div
+                        class="MuiBox-root css-0"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-1oqxamc-MuiTypography-root"
+                        >
+                          Tech Leads
+                        </p>
+                        <span
+                          class="MuiTypography-root MuiTypography-caption  css-bttn9n-MuiTypography-root"
+                        >
+                          Engineering Manager
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4  css-1lj5egr-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-19dee9g"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1w1rcmw-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root  css-xt5h0d-MuiCardContent-root"
+                  >
+                    <div
+                      class="MuiBox-root css-driq9y"
+                    >
+                      “
+                    </div>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1  css-1risbja-MuiTypography-root"
+                    >
+                      Department and growth mix are clear enough to drop straight into board updates.
+                    </p>
+                    <div
+                      class="MuiStack-root  css-1hyf038-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault  css-gd2dah-MuiAvatar-root"
+                      >
+                        L
+                      </div>
+                      <div
+                        class="MuiBox-root css-0"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1  css-1oqxamc-MuiTypography-root"
+                        >
+                          Leadership
+                        </p>
+                        <span
+                          class="MuiTypography-root MuiTypography-caption  css-bttn9n-MuiTypography-root"
+                        >
+                          VP, Operations
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-4jc6d9"
+          id="faq"
+        >
+          <div
+            class="MuiBox-root css-16ieni4"
+          >
+            <div
+              class="MuiBox-root css-y3ly9k"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                Questions
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-936k1o-MuiTypography-root"
+              >
+                Everything teams ask before rollout
+              </h2>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-8natme"
+          >
+            <div
+              class="MuiBox-root css-8u1zsh"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiAccordion-root MuiAccordion-rounded  css-10r2xz-MuiPaper-root-MuiAccordion-root"
+                style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+              >
+                <h3
+                  class="MuiAccordion-heading  css-rolk5j-MuiAccordion-heading"
+                >
+                  <div
+                    aria-expanded="false"
+                    class="MuiButtonBase-root  MuiAccordionSummary-root  css-1726laa-MuiButtonBase-root-MuiAccordionSummary-root"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiAccordionSummary-content  css-1betqn-MuiAccordionSummary-content"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1  css-19jz19x-MuiTypography-root"
+                      >
+                        Can I export data for finance or ops reviews?
+                      </p>
+                    </div>
+                    <div
+                      class="MuiAccordionSummary-expandIconWrapper  css-yw020d-MuiAccordionSummary-expandIconWrapper"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1ls7ddq-MuiSvgIcon-root"
+                        data-testid="ExpandMoreIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical  MuiCollapse-hidden  css-1ev76c2-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical  css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical  css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiAccordion-region "
+                        role="region"
+                      >
+                        <div
+                          class="MuiAccordionDetails-root  css-1iaksna-MuiAccordionDetails-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1  css-1yfmn5l-MuiTypography-root"
+                          >
+                            Yes — use the built-in exports in Employees and Departments to get a clean CSV anytime, filtered to exactly the slice you need.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1fqyxh7"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiAccordion-root MuiAccordion-rounded  css-10r2xz-MuiPaper-root-MuiAccordion-root"
+                style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+              >
+                <h3
+                  class="MuiAccordion-heading  css-rolk5j-MuiAccordion-heading"
+                >
+                  <div
+                    aria-expanded="false"
+                    class="MuiButtonBase-root  MuiAccordionSummary-root  css-1726laa-MuiButtonBase-root-MuiAccordionSummary-root"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiAccordionSummary-content  css-1betqn-MuiAccordionSummary-content"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1  css-19jz19x-MuiTypography-root"
+                      >
+                        Does it support remote and hybrid tracking?
+                      </p>
+                    </div>
+                    <div
+                      class="MuiAccordionSummary-expandIconWrapper  css-yw020d-MuiAccordionSummary-expandIconWrapper"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1ls7ddq-MuiSvgIcon-root"
+                        data-testid="ExpandMoreIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical  MuiCollapse-hidden  css-1ev76c2-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical  css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical  css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiAccordion-region "
+                        role="region"
+                      >
+                        <div
+                          class="MuiAccordionDetails-root  css-1iaksna-MuiAccordionDetails-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1  css-1yfmn5l-MuiTypography-root"
+                          >
+                            Dashboard charts already visualize remote and hybrid preferences without any extra setup or configuration.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-ytb0kv"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiAccordion-root MuiAccordion-rounded  css-10r2xz-MuiPaper-root-MuiAccordion-root"
+                style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+              >
+                <h3
+                  class="MuiAccordion-heading  css-rolk5j-MuiAccordion-heading"
+                >
+                  <div
+                    aria-expanded="false"
+                    class="MuiButtonBase-root  MuiAccordionSummary-root  css-1726laa-MuiButtonBase-root-MuiAccordionSummary-root"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiAccordionSummary-content  css-1betqn-MuiAccordionSummary-content"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1  css-19jz19x-MuiTypography-root"
+                      >
+                        How fast can we onboard?
+                      </p>
+                    </div>
+                    <div
+                      class="MuiAccordionSummary-expandIconWrapper  css-yw020d-MuiAccordionSummary-expandIconWrapper"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1ls7ddq-MuiSvgIcon-root"
+                        data-testid="ExpandMoreIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical  MuiCollapse-hidden  css-1ev76c2-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical  css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical  css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiAccordion-region "
+                        role="region"
+                      >
+                        <div
+                          class="MuiAccordionDetails-root  css-1iaksna-MuiAccordionDetails-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1  css-1yfmn5l-MuiTypography-root"
+                          >
+                            Most teams are running in under a day: set roles, add departments, and import employees in a single sitting.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-g6j60s"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiAccordion-root MuiAccordion-rounded  css-10r2xz-MuiPaper-root-MuiAccordion-root"
+                style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+              >
+                <h3
+                  class="MuiAccordion-heading  css-rolk5j-MuiAccordion-heading"
+                >
+                  <div
+                    aria-expanded="false"
+                    class="MuiButtonBase-root  MuiAccordionSummary-root  css-1726laa-MuiButtonBase-root-MuiAccordionSummary-root"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiAccordionSummary-content  css-1betqn-MuiAccordionSummary-content"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1  css-19jz19x-MuiTypography-root"
+                      >
+                        Is access role-based?
+                      </p>
+                    </div>
+                    <div
+                      class="MuiAccordionSummary-expandIconWrapper  css-yw020d-MuiAccordionSummary-expandIconWrapper"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-1ls7ddq-MuiSvgIcon-root"
+                        data-testid="ExpandMoreIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical  MuiCollapse-hidden  css-1ev76c2-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical  css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical  css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiAccordion-region "
+                        role="region"
+                      >
+                        <div
+                          class="MuiAccordionDetails-root  css-1iaksna-MuiAccordionDetails-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1  css-1yfmn5l-MuiTypography-root"
+                          >
+                            Protected routes and role-aware surfaces mean people only see what they should, by department and seniority.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <section
+        class="MuiBox-root css-13fpl40"
+      >
+        <div
+          aria-hidden="true"
+          class="MuiBox-root css-7iao98"
+        />
+        <div
+          class="MuiContainer-root MuiContainer-maxWidthMd  css-nvtv1h-MuiContainer-root"
+        >
+          <div
+            class="MuiBox-root css-y3ly9k"
+          >
+            <div
+              class="MuiBox-root css-1unaie2"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-igcryw-MuiTypography-root"
+              >
+                Get started
+              </p>
+              <h2
+                class="MuiTypography-root MuiTypography-body1  css-1aipnr6-MuiTypography-root"
+              >
+                Ready to see your workforce 
+                <span
+                  class="MuiBox-root css-1cv996i"
+                >
+                  come into focus
+                </span>
+                ?
+              </h2>
+              <p
+                class="MuiTypography-root MuiTypography-body1  css-1fwb67k-MuiTypography-root"
+              >
+                Jump into the dashboard, filter employees, and ship updates without extra tooling. No spreadsheets required.
+              </p>
+              <div
+                class="MuiStack-root  css-jqawk7-MuiStack-root"
+              >
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary  css-gbqpv0-MuiButtonBase-root-MuiButton-root"
+                  href="/dashboard"
+                  tabindex="0"
+                >
+                  Open Dashboard
+                  <span
+                    class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeLarge  css-3155yg-MuiButton-endIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                      data-testid="ArrowForwardIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary  css-1e74b2t-MuiButtonBase-root-MuiButton-root"
+                  href="/register"
+                  tabindex="0"
+                >
+                  Create account
+                </a>
+              </div>
+              <div
+                class="MuiStack-root  css-k0g22q-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root  css-fcz5d9-MuiStack-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                    data-testid="CheckCircleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                    />
+                  </svg>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-1xmxnxa-MuiTypography-root"
+                  >
+                    No credit card
+                  </p>
+                </div>
+                <div
+                  class="MuiStack-root  css-fcz5d9-MuiStack-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                    data-testid="CheckCircleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                    />
+                  </svg>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-1xmxnxa-MuiTypography-root"
+                  >
+                    Setup in under a day
+                  </p>
+                </div>
+                <div
+                  class="MuiStack-root  css-fcz5d9-MuiStack-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-2pmdpe-MuiSvgIcon-root"
+                    data-testid="CheckCircleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+                    />
+                  </svg>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2  css-1xmxnxa-MuiTypography-root"
+                  >
+                    Export-ready data
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Login.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Login.snapshot.test.jsx.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Login snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-txx31i"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-pmv2pw-MuiPaper-root-MuiCard-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiBox-root css-16l9zb1"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4  css-ol6fzo-MuiTypography-root"
+        >
+          Welcome back
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1  css-1edfpdg-MuiTypography-root"
+        >
+          Sign in to access your dashboard, manage employees, and keep your organization humming.
+        </p>
+        <div
+          class="MuiStack-root  css-jfdv4h-MuiStack-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1  css-j515ph-MuiTypography-root"
+          >
+            Why log in?
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            • Securely access the insights-rich dashboard.
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            • Manage teams, departments, and updates in one spot.
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+          >
+            • Pick up where you left off with your saved session.
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root  css-pe6mfu-MuiCardContent-root"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h5  css-12pus0r-MuiTypography-root"
+        >
+          Login
+        </h2>
+        <form>
+          <div
+            class="MuiStack-root  css-1sazv7p-MuiStack-root"
+          >
+            <div
+              class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for=":r0:"
+                id=":r0:-label"
+              >
+                Username
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+                style="font-family: Poppins, sans-serif;"
+              >
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+                  id=":r0:"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-1pbc52w"
+                  >
+                    <span>
+                      Username
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for=":r1:"
+                id=":r1:-label"
+              >
+                Password
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd  css-1wgn40h-MuiInputBase-root-MuiOutlinedInput-root"
+                style="font-family: Poppins, sans-serif;"
+              >
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input  MuiInputBase-inputAdornedEnd  css-lc42l8-MuiInputBase-input-MuiOutlinedInput-input"
+                  id=":r1:"
+                  type="password"
+                  value=""
+                />
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium  css-1i2hsuj-MuiInputAdornment-root"
+                >
+                  <button
+                    aria-label="toggle password visibility"
+                    class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium  css-1a7z5rc-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                      data-testid="VisibilityIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-1pbc52w"
+                  >
+                    <span>
+                      Password
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth  css-6m7w87-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="submit"
+            >
+              Login
+            </button>
+            <hr
+              class="MuiDivider-root MuiDivider-fullWidth  css-9mgopn-MuiDivider-root"
+            />
+            <div
+              class="MuiStack-root  css-aha7cr-MuiStack-root"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+              >
+                Don't have an account? 
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary  css-8iab9z-MuiButtonBase-root-MuiButton-root"
+                  href="/register"
+                  tabindex="0"
+                >
+                  Register
+                </a>
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+              >
+                Forgot your password? 
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary  css-8iab9z-MuiButtonBase-root-MuiButton-root"
+                  href="/verify-username"
+                  tabindex="0"
+                >
+                  Reset Password
+                </a>
+              </p>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Navbar.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Navbar.snapshot.test.jsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Navbar snapshot matches the rendered markup (signed out) 1`] = `
+<DocumentFragment>
+  <header
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4  MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic  css-1pbr7h-MuiPaper-root-MuiAppBar-root"
+    style="--Paper-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular  css-95f9g5-MuiToolbar-root"
+    >
+      <a
+        class="MuiTypography-root MuiTypography-h6  css-g5b1a4-MuiTypography-root"
+        href="/"
+      >
+        Employee Management System
+      </a>
+      <div
+        class="MuiBox-root css-k9kc57"
+      >
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-sz7e5e-MuiButtonBase-root-MuiButton-root"
+          href="/"
+          tabindex="0"
+        >
+          Home
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/dashboard"
+          tabindex="0"
+        >
+          Dashboard
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/employees"
+          tabindex="0"
+        >
+          Employees
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/departments"
+          tabindex="0"
+        >
+          Departments
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/profile"
+          tabindex="0"
+        >
+          Profile
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/login"
+          tabindex="0"
+        >
+          Login
+        </a>
+        <a
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit   MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit  css-1ofy68o-MuiButtonBase-root-MuiButton-root"
+          href="/register"
+          tabindex="0"
+        >
+          Register
+        </a>
+      </div>
+    </div>
+  </header>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/NewDepartmentForm.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/NewDepartmentForm.snapshot.test.jsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewDepartmentForm snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <form
+    class="MuiBox-root css-c0ojgy"
+  >
+    <h2>
+      Create New Department
+    </h2>
+    <div
+      class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-y4n9bg-MuiFormControl-root-MuiTextField-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary Mui-required  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="false"
+        for=":r0:"
+        id=":r0:-label"
+      >
+        Department Name
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk   css-wgai2y-MuiFormLabel-asterisk"
+        >
+           *
+        </span>
+      </label>
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+      >
+        <input
+          aria-invalid="false"
+          class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+          id=":r0:"
+          name="name"
+          required=""
+          type="text"
+          value=""
+        />
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-1pbc52w"
+          >
+            <span>
+              Department Name *
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary  css-joibnn-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="submit"
+    >
+      Save
+    </button>
+  </form>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/NotFoundPage.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/NotFoundPage.snapshot.test.jsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFoundPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-xkj9fj"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  css-1p70tfu-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiBox-root css-zrc5x4"
+      />
+      <div
+        class="MuiBox-root css-1cycpoc"
+      />
+      <div
+        class="MuiBox-root css-79elbk"
+      >
+        <div
+          class="MuiBox-root css-1oordai"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-txx3st-MuiSvgIcon-root"
+            data-testid="SearchOffIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3 6.08 3 3.28 5.64 3.03 9h2.02C5.3 6.75 7.18 5 9.5 5 11.99 5 14 7.01 14 9.5S11.99 14 9.5 14c-.17 0-.33-.03-.5-.05v2.02c.17.02.33.03.5.03 1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19z"
+            />
+            <path
+              d="M6.47 10.82 4 13.29l-2.47-2.47-.71.71L3.29 14 .82 16.47l.71.71L4 14.71l2.47 2.47.71-.71L4.71 14l2.47-2.47z"
+            />
+          </svg>
+        </div>
+        <h1
+          class="MuiTypography-root MuiTypography-h1  css-ilch5f-MuiTypography-root"
+        >
+          404
+        </h1>
+        <h5
+          class="MuiTypography-root MuiTypography-h5  css-xgg9j1-MuiTypography-root"
+        >
+          Page not found
+        </h5>
+        <p
+          class="MuiTypography-root MuiTypography-body1  css-1cxhnf5-MuiTypography-root"
+        >
+          The page you’re looking for doesn’t exist or may have moved. Check the URL, or head back to familiar ground.
+        </p>
+        <div
+          class="MuiStack-root  css-67e3wp-MuiStack-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary  css-dhcbp5-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge  css-hev6se-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                data-testid="HomeIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"
+                />
+              </svg>
+            </span>
+            Go to Home
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary   MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary  css-i5knbc-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeLarge  css-hev6se-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                data-testid="SpaceDashboardIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 21H5c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h6zm2 0h6c1.1 0 2-.9 2-2v-7h-8zm8-11V5c0-1.1-.9-2-2-2h-6v7z"
+                />
+              </svg>
+            </span>
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Passkeys.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Passkeys.snapshot.test.jsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Passkeys snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-nvw3k9"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-1feey5y-MuiPaper-root-MuiCard-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiBox-root css-1plzhfw"
+      >
+        <div
+          class="MuiStack-root  css-4ekims-MuiStack-root"
+        >
+          <div
+            class="MuiStack-root  css-1sos3zc-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-1qu83ua"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-xmrb5v-MuiSvgIcon-root"
+                data-testid="FingerprintIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28M3.5 9.72c-.1 0-.2-.03-.29-.09-.23-.16-.28-.47-.12-.7.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25.16.22.11.54-.12.7s-.54.11-.7-.12c-.9-1.26-2.04-2.25-3.39-2.94-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21m6.25 12.07c-.13 0-.26-.05-.35-.15-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39s-4.66 1.97-4.66 4.39c0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15m7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12M14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1-1.4-1.39-2.17-3.24-2.17-5.22 0-1.62 1.38-2.94 3.08-2.94s3.08 1.32 3.08 2.94c0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29-.49-1.31-.73-2.61-.73-3.96 0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <h4
+                class="MuiTypography-root MuiTypography-h4  css-ol6fzo-MuiTypography-root"
+              >
+                Passkeys
+              </h4>
+              <p
+                class="MuiTypography-root MuiTypography-body2  css-197vuy0-MuiTypography-root"
+              >
+                Sign in without a password using your device's biometrics or a security key.
+              </p>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary  Mui-disabled  MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary  css-er0vzm-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium  css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                data-testid="AddIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                />
+              </svg>
+            </span>
+            Add a passkey
+          </button>
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root  css-17si89s-MuiCardContent-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard  css-ipzprr-MuiPaper-root-MuiAlert-root"
+          role="alert"
+          style="--Paper-shadow: none;"
+        >
+          <div
+            class="MuiAlert-icon  css-1ytlwq5-MuiAlert-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit  css-1lzspe0-MuiSvgIcon-root"
+              data-testid="ReportProblemOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiAlert-message  css-1pxa9xg-MuiAlert-message"
+          >
+            This browser does not support passkeys. Try a modern browser such as Chrome, Safari, or Edge.
+          </div>
+        </div>
+        <div
+          class="MuiStack-root  css-1sazv7p-MuiStack-root"
+        >
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse  css-6xubvs-MuiSkeleton-root"
+            style="height: 84px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse  css-6xubvs-MuiSkeleton-root"
+            style="height: 84px;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Profile.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Profile.snapshot.test.jsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Profile snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiSnackbar-root MuiSnackbar-anchorOriginTopCenter  css-ikhur5-MuiSnackbar-root"
+    role="presentation"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard  css-6ecq4l-MuiPaper-root-MuiAlert-root"
+      direction="down"
+      role="alert"
+      style="--Paper-shadow: none; opacity: 1; transform: scale(1, 1); transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <div
+        class="MuiAlert-icon  css-1ytlwq5-MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit  css-1lzspe0-MuiSvgIcon-root"
+          data-testid="ReportProblemOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message  css-1pxa9xg-MuiAlert-message"
+      >
+        You must be logged in to view your profile. 
+        <span
+          style="color: rgb(63, 81, 181); text-decoration: underline; cursor: pointer; transition: color 0.1s;"
+        >
+          Login
+        </span>
+      </div>
+      <div
+        class="MuiAlert-action  css-ki1hdl-MuiAlert-action"
+      >
+        <button
+          aria-label="Close"
+          class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall  css-18qjhy-MuiButtonBase-root-MuiIconButton-root"
+          tabindex="0"
+          title="Close"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall  css-18w7uxr-MuiSvgIcon-root"
+            data-testid="CloseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    style="height: 20px;"
+  />
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/QuickActions.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/QuickActions.snapshot.test.jsx.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuickActions snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiSpeedDial-root MuiSpeedDial-directionUp  css-1isf2mj-MuiSpeedDial-root"
+    role="presentation"
+  >
+    <button
+      aria-controls="Quickactions-actions"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Quick actions"
+      class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-primary   MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-primary  MuiSpeedDial-fab  css-1cpgcd7-MuiButtonBase-root-MuiFab-root-MuiSpeedDial-fab"
+      style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiSpeedDialIcon-root  css-ohncnb-MuiSpeedDialIcon-root"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSpeedDialIcon-openIcon  css-20bmp1-MuiSvgIcon-root"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  MuiSpeedDialIcon-icon  css-20bmp1-MuiSvgIcon-root"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+          />
+        </svg>
+      </span>
+    </button>
+    <div
+      aria-orientation="vertical"
+      class="MuiSpeedDial-actions MuiSpeedDial-actionsClosed  css-8xlyxc-MuiSpeedDial-actions"
+      id="Quickactions-actions"
+      role="menu"
+    >
+      <button
+        aria-label="Dashboard"
+        class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default   MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default  MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed  css-jl45v1-MuiButtonBase-root-MuiFab-root-MuiSpeedDialAction-fab"
+        data-mui-internal-clone-element="true"
+        role="menuitem"
+        style="transition-delay: 90ms;"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+          data-testid="DashboardIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M3 13h8V3H3zm0 8h8v-6H3zm10 0h8V11h-8zm0-18v6h8V3z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add Employee"
+        class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default   MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default  MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed  css-jl45v1-MuiButtonBase-root-MuiFab-root-MuiSpeedDialAction-fab"
+        data-mui-internal-clone-element="true"
+        role="menuitem"
+        style="transition-delay: 60ms;"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+          data-testid="GroupAddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M22 9V7h-2v2h-2v2h2v2h2v-2h2V9zM8 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4m0 1c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4m4.51-8.95C13.43 5.11 14 6.49 14 8s-.57 2.89-1.49 3.95C14.47 11.7 16 10.04 16 8s-1.53-3.7-3.49-3.95m4.02 9.78C17.42 14.66 18 15.7 18 17v3h2v-3c0-1.45-1.59-2.51-3.47-3.17"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add Department"
+        class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default   MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default  MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed  css-jl45v1-MuiButtonBase-root-MuiFab-root-MuiSpeedDialAction-fab"
+        data-mui-internal-clone-element="true"
+        role="menuitem"
+        style="transition-delay: 30ms;"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+          data-testid="ApartmentIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M17 11V3H7v4H3v14h8v-4h2v4h8V11zM7 19H5v-2h2zm0-4H5v-2h2zm0-4H5V9h2zm4 4H9v-2h2zm0-4H9V9h2zm0-4H9V5h2zm4 8h-2v-2h2zm0-4h-2V9h2zm0-4h-2V5h2zm4 12h-2v-2h2zm0-4h-2v-2h2z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/Register.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/Register.snapshot.test.jsx.snap
@@ -1,0 +1,275 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Register snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-1176emn"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1  MuiCard-root  css-ibjc0l-MuiPaper-root-MuiCard-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiBox-root css-16l9zb1"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4  css-ol6fzo-MuiTypography-root"
+        >
+          Create your account
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1  css-1edfpdg-MuiTypography-root"
+        >
+          Join the Employee Management platform to streamline onboarding, manage departments, and get insights fast.
+        </p>
+        <div
+          class="MuiStack-root  css-1l9qugs-MuiStack-root"
+        >
+          <div
+            class="MuiStack-root  css-kdc3n8-MuiStack-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="RocketLaunchIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M9.19 6.35c-2.04 2.29-3.44 5.58-3.57 5.89L2 10.69l4.05-4.05c.47-.47 1.15-.68 1.81-.55zM11.17 17s3.74-1.55 5.89-3.7c5.4-5.4 4.5-9.62 4.21-10.57-.95-.3-5.17-1.19-10.57 4.21C8.55 9.09 7 12.83 7 12.83zm6.48-2.19c-2.29 2.04-5.58 3.44-5.89 3.57L13.31 22l4.05-4.05c.47-.47.68-1.15.55-1.81zM9 18c0 .83-.34 1.58-.88 2.12C6.94 21.3 2 22 2 22s.7-4.94 1.88-6.12C4.42 15.34 5.17 15 6 15c1.66 0 3 1.34 3 3m4-9c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+            >
+              Launch-ready in minutes
+            </p>
+          </div>
+          <div
+            class="MuiStack-root  css-kdc3n8-MuiStack-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="ShieldIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5z"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+            >
+              Secure access with protected routes
+            </p>
+          </div>
+          <div
+            class="MuiStack-root  css-kdc3n8-MuiStack-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+              data-testid="CheckCircleIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body2  css-1nmqws6-MuiTypography-root"
+            >
+              Export-ready data out of the box
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiCardContent-root  css-1jatqw4-MuiCardContent-root"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h5  css-12pus0r-MuiTypography-root"
+        >
+          Register
+        </h2>
+        <form>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r0:"
+              id=":r0:-label"
+            >
+              Username
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+              style="font-family: Poppins, sans-serif;"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r0:"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Username
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r1:"
+              id=":r1:-label"
+            >
+              Password
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd  css-1wgn40h-MuiInputBase-root-MuiOutlinedInput-root"
+              style="font-family: Poppins, sans-serif;"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input  MuiInputBase-inputAdornedEnd  css-lc42l8-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r1:"
+                type="password"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium  css-1i2hsuj-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="toggle password visibility"
+                  class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium  css-1a7z5rc-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="VisibilityIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Password
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r2:"
+              id=":r2:-label"
+            >
+              Confirm Password
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd  css-1wgn40h-MuiInputBase-root-MuiOutlinedInput-root"
+              style="font-family: Poppins, sans-serif;"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input  MuiInputBase-inputAdornedEnd  css-lc42l8-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r2:"
+                type="password"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium  css-1i2hsuj-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="toggle confirm password visibility"
+                  class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium  css-1a7z5rc-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="VisibilityIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Confirm Password
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth  css-6m7w87-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="submit"
+          >
+            Register
+          </button>
+          <p
+            class="MuiTypography-root MuiTypography-body1  css-1c0a1cb-MuiTypography-root"
+          >
+            Already have an account? 
+            <a
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary   MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-1apkmlw-MuiButtonBase-root-MuiButton-root"
+              href="/login"
+              tabindex="0"
+            >
+              Login
+            </a>
+          </p>
+        </form>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/ResetPassword.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/ResetPassword.snapshot.test.jsx.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResetPassword snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-1fjjxay"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  css-1d606iz-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiBox-root css-115j56r"
+      />
+      <div
+        class="MuiBox-root css-19u9mpi"
+      />
+      <div
+        class="MuiBox-root css-79elbk"
+      >
+        <div
+          class="MuiBox-root css-cacgvk"
+        >
+          <div
+            class="MuiBox-root css-1gh7hit"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-52ct2d-MuiSvgIcon-root"
+              data-testid="LockResetIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M13 3c-4.97 0-9 4.03-9 9H1l4 4 4-4H6c0-3.86 3.14-7 7-7s7 3.14 7 7-3.14 7-7 7c-1.9 0-3.62-.76-4.88-1.99L6.7 18.42C8.32 20.01 10.55 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9m2 8v-1c0-1.1-.9-2-2-2s-2 .9-2 2v1c-.55 0-1 .45-1 1v3c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-3c0-.55-.45-1-1-1m-1 0h-2v-1c0-.55.45-1 1-1s1 .45 1 1z"
+              />
+            </svg>
+          </div>
+          <h2
+            class="MuiTypography-root MuiTypography-h5  css-1d0c9so-MuiTypography-root"
+          >
+            Reset Password
+          </h2>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-9isvqg-MuiTypography-root"
+          >
+            Choose a new password for your account.
+          </p>
+        </div>
+        <form>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary Mui-disabled  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r0:"
+              id=":r0:-label"
+            >
+              Username
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input  Mui-disabled  css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+                disabled=""
+                id=":r0:"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Username
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r1:"
+              id=":r1:-label"
+            >
+              New Password
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd  css-1wgn40h-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input  MuiInputBase-inputAdornedEnd  css-lc42l8-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r1:"
+                type="password"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium  css-1i2hsuj-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="toggle password visibility"
+                  class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium  css-1a7z5rc-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="VisibilityIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    New Password
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r2:"
+              id=":r2:-label"
+            >
+              Confirm New Password
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd  css-1wgn40h-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input  MuiInputBase-inputAdornedEnd  css-lc42l8-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r2:"
+                type="password"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium  css-1i2hsuj-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="toggle confirm password visibility"
+                  class="MuiButtonBase-root  MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium  css-1a7z5rc-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-20bmp1-MuiSvgIcon-root"
+                    data-testid="VisibilityIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Confirm New Password
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth  css-10l9h5n-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="submit"
+          >
+            Reset Password
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/__tests__/snapshots/__snapshots__/VerifyUsername.snapshot.test.jsx.snap
+++ b/frontend/__tests__/snapshots/__snapshots__/VerifyUsername.snapshot.test.jsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VerifyUsername snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-1fjjxay"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0  css-1d606iz-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiBox-root css-115j56r"
+      />
+      <div
+        class="MuiBox-root css-19u9mpi"
+      />
+      <div
+        class="MuiBox-root css-79elbk"
+      >
+        <div
+          class="MuiBox-root css-cacgvk"
+        >
+          <div
+            class="MuiBox-root css-1gh7hit"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium  css-52ct2d-MuiSvgIcon-root"
+              data-testid="PersonSearchIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                cx="10"
+                cy="8"
+                r="4"
+              />
+              <path
+                d="M10.35 14.01C7.62 13.91 2 15.27 2 18v2h9.54c-2.47-2.76-1.23-5.89-1.19-5.99m9.08 4.01c.36-.59.57-1.28.57-2.02 0-2.21-1.79-4-4-4s-4 1.79-4 4 1.79 4 4 4c.74 0 1.43-.22 2.02-.57L20.59 22 22 20.59zM16 18c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2"
+              />
+            </svg>
+          </div>
+          <h2
+            class="MuiTypography-root MuiTypography-h5  css-1d0c9so-MuiTypography-root"
+          >
+            Verify Username
+          </h2>
+          <p
+            class="MuiTypography-root MuiTypography-body2  css-9isvqg-MuiTypography-root"
+          >
+            Enter your username to start resetting your password.
+          </p>
+        </div>
+        <form>
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth  MuiTextField-root  css-8szo48-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  MuiFormLabel-colorPrimary  MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined  css-1q964xs-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for=":r0:"
+              id=":r0:-label"
+            >
+              Username
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root  MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl  css-1o0kqxp-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input   css-1jk99ih-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r0:"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline  css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1pbc52w"
+                >
+                  <span>
+                    Username
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth   MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth  css-10l9h5n-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="submit"
+          >
+            Verify Username
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -2,6 +2,50 @@ import '@testing-library/jest-dom';
 
 // jest.setup.js
 
+// --- jsdom polyfills ---
+// jsdom omits these browser APIs that MUI, animations, and a few components
+// reach for; stub them (inert) so component renders don't crash in tests.
+if (typeof window !== 'undefined') {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = (query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+  if (typeof window.scrollTo !== 'function') {
+    window.scrollTo = () => {};
+  }
+  if (typeof window.HTMLElement !== 'undefined') {
+    window.HTMLElement.prototype.scrollIntoView = () => {};
+    // autoFocus toggles MUI focus classes, and jsdom applies it inconsistently
+    // across environments (focuses locally but not on CI), which would make
+    // focus-sensitive snapshots flaky. Neutralize focus so the rendered markup
+    // is the unfocused state everywhere.
+    window.HTMLElement.prototype.focus = () => {};
+  }
+}
+
+class MockObserver {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+if (typeof global.ResizeObserver === 'undefined') global.ResizeObserver = MockObserver;
+if (typeof global.IntersectionObserver === 'undefined')
+  global.IntersectionObserver = MockObserver;
+
 // Keep the original console.error
 const originalConsoleError = console.error;
 


### PR DESCRIPTION
## What

The frontend had behavioral tests but **no snapshot coverage**. This adds Jest + React Testing Library **snapshot tests for all 17 screens**:

LandingPage, Login, Register, ResetPassword, VerifyUsername, Dashboard, EmployeeList, EmployeeForm, DepartmentList, DepartmentForm, NewDepartmentForm, Profile, Passkeys, NotFoundPage, QuickActions, Navbar, Footer.

Each test renders the screen inside a `MemoryRouter` with its services mocked and asserts the rendered markup with `toMatchSnapshot()` — so unintended UI changes surface as a diff. Tests live in `frontend/__tests__/snapshots/`.

## Harness

`jest.setup.js` gains jsdom polyfills (`matchMedia`, `scrollTo`, `scrollIntoView`, `Resize`/`IntersectionObserver`) and a global `autoFocus` neutralization (jsdom applies focus inconsistently across environments). No config or dependency changes otherwise.

## Determinism — passes identically on local + CI regardless of when/where

- **LandingPage** — WebGL 3D hero stubbed.
- **Dashboard** — `react-chartjs-2` stubbed (charts need a canvas/GPU).
- **Footer** — `Date` frozen (renders the current year).
- **Data screens** — services mocked as pending, so they render their deterministic loading state offline (no async act races).

## Verification

```
Test Suites: 25 passed, 25 total   (17 snapshot + 8 existing behavioral)
Tests:       37 passed, 37 total
Snapshots:   17 passed, 17 total
```

Snapshot suites verified against the committed baselines under **UTC, Pacific/Kiritimati (UTC+14), and Pacific/Pago_Pago (UTC-11)** — all pass. The 8 existing behavioral suites still pass with the updated setup.

Docs updated: root `README.md` and `frontend/README.md` testing sections now document the snapshot suites and how to run/update them. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)