### PR TITLE
style(frontend): apply prettier formatting to jest.setup.js

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 // reach for; stub them (inert) so component renders don't crash in tests.
 if (typeof window !== 'undefined') {
   if (typeof window.matchMedia !== 'function') {
-    window.matchMedia = (query) => ({
+    window.matchMedia = query => ({
       matches: false,
       media: query,
       onchange: null,
@@ -43,8 +43,7 @@ class MockObserver {
   }
 }
 if (typeof global.ResizeObserver === 'undefined') global.ResizeObserver = MockObserver;
-if (typeof global.IntersectionObserver === 'undefined')
-  global.IntersectionObserver = MockObserver;
+if (typeof global.IntersectionObserver === 'undefined') global.IntersectionObserver = MockObserver;
 
 // Keep the original console.error
 const originalConsoleError = console.error;


### PR DESCRIPTION
## Summary
Applies `npm run format` (Prettier) to `frontend/jest.setup.js`, which was left unformatted. Formatting only — no behavior change.

- Arrow-fn param `(query) =>` → `query =>`
- Single-line `IntersectionObserver` guard collapsed to match Prettier's print width.

## Testing
- `npm run format` (root + frontend) is now idempotent — re-running produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)